### PR TITLE
Added sections to blueprint

### DIFF
--- a/Parse Result.md
+++ b/Parse Result.md
@@ -5,10 +5,10 @@ This document describes API Blueprint Serialized Parse Result Media Types – th
 
 ## Version
 
-+ **Version**: 2.0
++ **Version**: 2.1
 + **Created**: 2014-06-09
-+ **Updated**: 2014-10-07
-+ **AST Serialization Media Types**: 2.1
++ **Updated**: 2014-11-27
++ **AST Serialization Media Types**: 3.0
 
 ---
 
@@ -17,7 +17,6 @@ This document describes API Blueprint Serialized Parse Result Media Types – th
 + [Parse Result Description](#parse-result-description)
 + [Media Types](#media-types)
 + [JSON serialization](#json-serialization)
-+ [YAML serialization](#yaml-serialization)
 + [Keys description](#keys-description)
 
 ---
@@ -34,10 +33,10 @@ Following is the descripton of Parse Result media types using the [MSON](https:/
 - `warnings` (array[[Warning](#warning)]) - Ordered array of warnings occurred during the parsing, if any
 
 ### AST
-This object is the [Blueprint](README.md#blueprint-object) object as defined in the [AST Blueprint serialization Media Type v2.1](https://github.com/apiaryio/api-blueprint-ast).
+This object is the [Blueprint](README.md#blueprint-object) object as defined in the [AST Blueprint serialization Media Type](https://github.com/apiaryio/api-blueprint-ast).
 
 ### Source Map
-This object is the [Blueprint Source Map](README.md#blueprint-source-map) object as defined in [AST Blueprint serialization Media Type v2.1](https://github.com/apiaryio/api-blueprint-ast).
+This object is the [Blueprint Source Map](README.md#blueprint-source-map) object as defined in [AST Blueprint serialization Media Type](https://github.com/apiaryio/api-blueprint-ast).
 
 ### Error
 
@@ -77,19 +76,19 @@ Two supported, feature-equal serialization formats are JSON and YAML:
 Parser Result Media Types inherit from the respective [AST Serialization Type](README.md):
 
 + [`application/vnd.apiblueprint.ast.*+json`](#json-serialization)
-+ [`application/vnd.apiblueprint.ast.*+yaml`](#yaml-serialization)
++ `application/vnd.apiblueprint.ast.*+yaml`
 + [`application/vnd.apiblueprint.sourcemap+json`](#json-serialization)
-+ [`application/vnd.apiblueprint.sourcemap+yaml`](#yaml-serialization)
++ `application/vnd.apiblueprint.sourcemap+yaml`
 
 ### JSON Serialization
 
-`application/vnd.apiblueprint.parseresult.*+json; version=2.0`
+`application/vnd.apiblueprint.parseresult.*+json; version=2.1`
 
 ```json
 {
-  "_version": "2.0",
+  "_version": "2.1",
   "ast": {
-    "_version": "2.1",
+    "_version": "3.0",
 
     ...
   },
@@ -120,31 +119,3 @@ Parser Result Media Types inherit from the respective [AST Serialization Type](R
   ]
 }
 ```
-
-### YAML Serialization
-
-`application/vnd.apiblueprint.parseresult.*+yaml; version=2.0`
-
-```yaml
-_version: "2.0"
-ast:
-  _version: "2.1"
-
-  ...
-sourcemap:
-  ...
-error:
-  code: <error code>
-  message: "<error message>"
-  location:
-    - index: <character index>
-      length: <character count>
-
-warnings:
-  - code: <warning code>
-    message: "<warning message>"
-    location:
-      - index: <character index>
-        length: <character count>
-```
-

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 
 + **Version**: 3.0
 + **Created**: 2013-08-30
-+ **Updated**: 2014-11-24
++ **Updated**: 2014-11-26
 
 ---
 
@@ -28,9 +28,8 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 + [AST Description](#ast-description)
 + [Source map Description](#source-map-description)
 + [Media Types](#media-types)
-+ [JSON serialization](#json-serialization)
-+ [YAML serialization](#yaml-serialization)
 + [Keys description](#keys-description)
++ [Example: JSON serialization](#json-serialization)
 + [Serialization in Snow Crash](#serialization-in-snow-crash)
 + [Serialized Parsing Result Media Types][parsing media types]
 
@@ -148,34 +147,33 @@ A reference object which is used whenever there is a reference to a [Resource Mo
 
 + `id` (string) - The identifier (name) of the reference
 
-### Attributes
+### Attributes ([Data Structure][])
 
-Definition of the respective data structure attributes as described using the [MSON][] syntax.
+Data structure definition as written in an API Blueprint [Attributes section][Attribute section].
 
-> **NOTE:** Properties of this object may use types defined in [MSON AST][]. 
+> **Note:** The `name` property of the [Data Structure][]'s `type` property is only present when the respective [Attribute section][] defines an MSON named type, such as in the context of the [Resource section][]. Otherwise (in the case of a Payload, Action or an unnamed Resource) the Attributes section is considered to be anonymous named type.
 
-#### Properties
+### Data Structure
 
-+ `name` ([Type Name][]) 
+Definition of an [MSON][] data structure.
 
-    Name of the type being defined, see MSON AST's [Type Name][].
+> **NOTE:** Properties of this object may use some types defined in the [MSON AST][]. 
 
-    This property is only present when the [Attribute section][] defines an MSON named type, such as in the context of the [Resource section][].
+#### Properties 
++ `type` ([Named Type][]) - Data Structure as described in the source API Blueprint
 
-+ `base` ([Type Definition][])
++ `resolvedType` ([Named Type][])
 
-    Ancestor type as defined by the MSON AST's [Type Definition][].
+    `type` property [Named Type][] as resolved by parser harness or subsequent tooling. Usually created by expanding Type references.
 
-+ `sections` (array[[Type Section][]])
-
-    Ordered list of type sections as defined by the MSON AST's [Type Section][].
+    If present, this subtree must be a super set of the `type` property sub tree. In other words it must be safe to use  `resolvedType` instead of `type`, when presented.
 
 ### Data Structures
 
-List of arbitrary data structures defined as [MSON Named Types][].
+List of arbitrary data structures defined in API Blueprint.
 
 #### Properties
-- `types` (array[[Named Type][]]) - Array of defined types
++ `types` (array[[Data Structure][]]) - Array of defined data structures
 
 ---
 
@@ -301,7 +299,7 @@ For the [API Blueprint Source Map](#source-map-description)
 
 ### JSON Serialization
 
-`application/vnd.apiblueprint.ast.raw+json; version=2.1`
+`application/vnd.apiblueprint.ast.raw+json; version=3.0`
 
 ```json
 {
@@ -332,6 +330,17 @@ For the [API Blueprint Source Map](#source-map-description)
                 "value": "<HTTP header field value>"
               }
             ],
+            "attributes": {
+              "type": {
+                "name": null,
+                "base": {
+                  "typeSpecification": {
+                    "name": "<sub-type>"
+                  }
+                },
+                "sections": null
+              }
+            },
             "body": "<resource model body>",
             "schema": "<resource model schema>"
           },
@@ -351,9 +360,17 @@ For the [API Blueprint Source Map](#source-map-description)
             }
           ],
           "attributes": {
-            "name": <MSON Type Name>,
-            "base": <MSON Type Definition>,
-            "sections": [ <MSON Type Section> ]
+            "type": {
+              "name": {
+                "literal": "<resource name>"
+              },
+              "base": {
+                "typeSpecification": {
+                  "name": "<sub-type>"
+                }
+              },
+              "sections": null
+            }
           },
           "actions": [
             {
@@ -376,9 +393,16 @@ For the [API Blueprint Source Map](#source-map-description)
                 }
               ],
               "attributes": {
-                "base": <MSON Type Definition>,
-                "sections": [ <MSON Type Section> ]
-              }, 
+                "type": {
+                  "name": null,
+                  "base": {
+                    "typeSpecification": {
+                      "name": "<sub-type>"
+                    }
+                  },
+                  "sections": null
+                }
+              },
               "examples": [
                 {
                   "name": "<transaction example name>",
@@ -394,8 +418,15 @@ For the [API Blueprint Source Map](#source-map-description)
                         }
                       ],
                       "attributes": {
-                        "base": <MSON Type Definition>,
-                        "sections": [ <MSON Type Section> ]
+                        "type": {
+                          "name": null,
+                          "base": {
+                            "typeSpecification": {
+                              "name": "<sub-type>"
+                            }
+                          },
+                          "sections": null
+                        }
                       },
                       "body": "<request body>",
                       "schema": "<request schema>"
@@ -412,8 +443,15 @@ For the [API Blueprint Source Map](#source-map-description)
                         }
                       ],
                       "attributes": {
-                        "base": <MSON Type Definition>,
-                        "sections": [ <MSON Type Section> ]
+                        "type": {
+                          "name": null,
+                          "base": {
+                            "typeSpecification": {
+                              "name": "<sub-type>"
+                            }
+                          },
+                          "sections": null
+                        }
                       },
                       "body": "<response body>",
                       "schema": "<response schema>"
@@ -644,7 +682,7 @@ For the [API Blueprint Source Map](#source-map-description)
                       "name": [],
                       "reference": [
                         [1270, 24]
-                      ]
+                      ],
                       "description": [
                         [214, 29]
                       ],
@@ -670,354 +708,6 @@ For the [API Blueprint Source Map](#source-map-description)
     }
   ]
 }
-```
-
-### YAML Serialization
-
-`application/vnd.apiblueprint.ast.raw+yaml; version=2.1`
-
-```yaml
-_version: <AST version>
-
-metadata:
-- name: "<metadata key name>"
-  value: "<metadata value>"
-
-name: "<API name>"
-description: "<API description>"
-
-resourceGroups:
-- name: "<resource group name>"
-  description: "<resource group description>"
-
-  resources:
-  - name: "<resource name>"
-    description: "<resource description>"
-    uriTemplate: "<resource URI template>"
-
-    model:
-      name: "<resource model name>"
-      description: "<resource model description>"
-
-      headers:
-      - name: "<HTTP header field name>"
-        value: "<HTTP header field value>"
-
-      body: "<resource model body>"
-      schema: "<resource model schema>"
-
-    parameters:
-    - name: "<name>"
-      description: "<description>"
-      type: "<type>"
-      required: "<required parameter flag>"
-      default: "<default value>"
-      example: "<example value>"
-      values:
-      - value: "<enum element>"
-
-    attributes:
-      name: <MSON Type Name>
-      base: <MSON Type Definition>
-      sections:
-        - <MSON Type Section>
-
-    actions:
-    - name: "<action name>"
-      description: "<action description>"
-      method: "<action HTTP request method>"
-
-      parameters:
-      - name: "<name>"
-        description: "<description>"
-        type: "<type>"
-        required: "<required parameter flag>"
-        default: "<default value>"
-        example: "<example value>"
-        values:
-        - value: "<enum element>"
-
-      attributes:
-        base: <MSON Type Definition>
-        sections:
-          - <MSON Type Section>
-
-      examples:
-      - name: "<transaction example name>"
-        description: "<transaction example name>"
-
-        requests:
-        - name: "<request name>"
-          description: "<request description>"
-
-          headers:
-          - name: "<HTTP header field name>"
-            value: "<HTTP header field value>"
-
-          attributes:
-            base: <MSON Type Definition>
-            sections:
-              - <MSON Type Section>
-
-          body: "<request body>"
-          schema: "<request schema>"
-
-        responses:
-        - name: "<response HTTP status code>"
-          description: "<response description>"
-
-          headers:
-          - name: "<HTTP header field name>"
-            value: "<HTTP header field value>"
-
-          attributes:
-            base: <MSON Type Definition>
-            sections:
-              - <MSON Type Section>
-
-          body: "<response body>"
-          schema: "<response schema>"
-
-    - name: "<action name>"
-      description: "<action description>"
-      method: "<action HTTP request method>"
-      parameters:
-
-      examples:
-      - name: "<transaction example name>"
-        reference:
-          id: "<resource model name>"
-        description: "<transaction example name>"
-
-        responses:
-        - name: "<response HTTP status code>"
-          description: "<resource model description>"
-
-          headers:
-          - name: "<HTTP header field name>"
-            value: "<HTTP header field value>"
-
-          body: "<resource model body>"
-          schema: "<resource model schema>"
-```
-
-`application/vnd.apiblueprint.sourcemap+yaml; version=2.1`
-
-```yaml
-metadata:
--
-  -
-    - 0
-    - 39
-name:
--
-  - 39
-  - 13
-description:
--
-  - 52
-  - 19
-resourceGroups:
-- name:
-  -
-    - 71
-    - 30
-  description:
-  -
-    - 101
-    - 30
-  resources:
-  - name:
-    -
-      - 131
-      - 46
-    description:
-    -
-      - 177
-      - 24
-    uriTemplate:
-    -
-      - 131
-      - 46
-    model:
-      name:
-      -
-        - 131
-        - 46
-      description:
-      -
-        - 214
-        - 29
-      headers:
-      -
-        -
-          - 267
-          - 56
-      body:
-      -
-        - 344
-        - 26
-      schema:
-      -
-        - 393
-        - 28
-    parameters:
-    - name:
-      -
-        - 441
-        - 81
-      description:
-      -
-        - 441
-        - 81
-      type:
-      -
-        - 441
-        - 81
-      required:
-      -
-        - 441
-        - 81
-      default:
-      -
-        - 441
-        - 81
-      example:
-      -
-        - 441
-        - 81
-      values:
-      - 
-        -
-          - 552
-          - 19
-    actions:
-    - name:
-      -
-        - 572
-        - 24
-      description:
-      -
-        - 596
-        - 22
-      method:
-      -
-        - 572
-        - 24
-      parameters:
-      - name:
-        -
-          - 637
-          - 81
-        description:
-        -
-          - 637
-          - 81
-        type:
-        -
-          - 637
-          - 81
-        required:
-        -
-          - 637
-          - 81
-        default:
-        -
-          - 637
-          - 81
-        example:
-        -
-          - 637
-          - 81
-        values:
-        - 
-          -
-            - 748
-            - 19
-      examples:
-      - name: []
-        description: []
-        requests:
-        - name:
-          -
-            - 770
-            - 24
-          description:
-          -
-            - 798
-            - 22
-          headers:
-          -
-            -
-              - 844
-              - 56
-          body:
-          -
-            - 921
-            - 19
-          schema:
-          -
-            - 963
-            - 21
-        responses:
-        - name: []
-          description:
-          -
-            - 1029
-            - 23
-          headers:
-          -
-            -
-              - 1076
-              - 56
-          body:
-          -
-            - 1153
-            - 20
-          schema:
-          -
-            - 1196
-            - 22
-    - name:
-      -
-        - 1219
-        - 24
-      description:
-      -
-        - 1243
-        - 22
-      method:
-      -
-        - 1219
-        - 24
-      parameters: []
-      examples:
-      - name: []
-        description: []
-        requests: []
-        responses:
-        - name: []
-          reference:
-          -
-            - 1270
-            - 24
-          description:
-          -
-            - 214
-            - 29
-          headers:
-          -
-            -
-              - 267
-              - 56
-          body:
-          -
-            - 344
-            - 26
-          schema:
-          -
-            - 393
-            - 28
 ```
 
 ## Serialization in Snow Crash
@@ -1051,4 +741,5 @@ MIT License. See the [LICENSE](LICENSE) file.
 [Resource section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-resource-section
 
 [Attributes]: #attributes
+[Data Structure]: #data-structure
 [Data Structures]: #data-structures

--- a/README.md
+++ b/README.md
@@ -110,19 +110,13 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
 + `description` (string) - Description of the payload (`.raw` or `.html`)
 + `attributes` ([Attributes][]) - Description of the message-body attributes
 + `headers` (string) - Ordered array of HTTP headers that are expected to be transferred with HTTP message represented by this payload
-+ `bodyAsset` ([Asset][]) - Message-body asset
-+ `body` (string) 
-    
-    **Deprecated** – please use `bodyAsset` instead.
++ `bodyAsset` ([Asset][])
 
-    _An entity body to be transferred with HTTP message represented by this payload._
+    An entity body to be transferred with HTTP message represented by this payload.
 
-+ `schemaAsset` ([Asset][]) - Validation schema for message-body asset. 
-+ `schema` (string)
++ `schemaAsset` ([Asset][])
 
-    **Deprecated** – please use `schemaAsset` instead.
-
-    _A validation schema for the entity body as defined in `body`._
+    A validation schema for the entity body as defined in `bodyAsset`.
 
 ### Asset
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 + [Source map Description](#source-map-description)
 + [Media Types](#media-types)
 + [Keys description](#keys-description)
-+ [Example: JSON serialization](#json-serialization)
++ [Example: JSON serialization](#example-json-serialization)
 + [Serialization in Snow Crash](#serialization-in-snow-crash)
 + [Serialized Parsing Result Media Types][parsing media types]
 
@@ -110,8 +110,30 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
 + `description` (string) - Description of the payload (`.raw` or `.html`)
 + `attributes` ([Attributes][]) - Description of the message-body attributes
 + `headers` (string) - Ordered array of HTTP headers that are expected to be transferred with HTTP message represented by this payload
-+ `body` (string) - An entity body to be transferred with HTTP message represented by this payload
-+ `schema` (string) - A validation schema for the entity body as defined in `body`
++ `bodyAsset` ([Asset][]) - Message-body asset
++ `body` (string) 
+    
+    **Deprecated** – please use `bodyAsset` instead.
+
+    _An entity body to be transferred with HTTP message represented by this payload._
+
++ `schemaAsset` ([Asset][]) - Validation schema for message-body asset. 
++ `schema` (string)
+
+    **Deprecated** – please use `schemaAsset` instead.
+
+    _A validation schema for the entity body as defined in `body`._
+
+### Asset
+
+An [API Blueprint asset][].
+
+#### Properties
++ `asset` (string) - The Asset in its textual representation, as written in the source API Blueprint
+
++ `resolvedAsset` (string)
+
+    `asset` property `string` as resolved by parser harness or subsequent tooling. Usually created from a [Data Structure][] description or fetching the Asset from an URL. 
 
 ### Parameter
 
@@ -166,7 +188,7 @@ Definition of an [MSON][] data structure.
 
     `type` property [Named Type][] as resolved by parser harness or subsequent tooling. Usually created by expanding Type references.
 
-    If present, this subtree must be a super set of the `type` property sub tree. In other words it must be safe to use  `resolvedType` instead of `type`, when presented.
+    If present, this subtree MUST be a super set of the `type` property sub tree.
 
 ### Data Structures
 
@@ -297,7 +319,7 @@ For the [API Blueprint Source Map](#source-map-description)
 + `application/vnd.apiblueprint.sourcemap+json`
 + `application/vnd.apiblueprint.sourcemap+yaml`
 
-### JSON Serialization
+### Example: JSON Serialization
 
 `application/vnd.apiblueprint.ast.raw+json; version=3.0`
 
@@ -341,8 +363,12 @@ For the [API Blueprint Source Map](#source-map-description)
                 "sections": null
               }
             },
-            "body": "<resource model body>",
-            "schema": "<resource model schema>"
+            "bodyAsset": {
+              "asset": "<resource model body>"
+            },
+            "schemaAsset": {
+              "asset": "<resource model schema>"
+            }
           },
           "parameters": [
             {
@@ -428,8 +454,12 @@ For the [API Blueprint Source Map](#source-map-description)
                           "sections": null
                         }
                       },
-                      "body": "<request body>",
-                      "schema": "<request schema>"
+                      "bodyAsset": {
+                        "asset": "<request body>"
+                      },
+                      "schemaAsset": {
+                        "asset": "<request schema>"
+                      }
                     }
                   ],
                   "responses": [
@@ -453,8 +483,12 @@ For the [API Blueprint Source Map](#source-map-description)
                           "sections": null
                         }
                       },
-                      "body": "<response body>",
-                      "schema": "<response schema>"
+                      "bodyAsset": {
+                        "asset": "<response body>"
+                      },
+                      "schemaAsset": {
+                        "asset": "<response schema>"
+                      }
                     }
                   ]
                 }
@@ -482,8 +516,12 @@ For the [API Blueprint Source Map](#source-map-description)
                           "value": "<HTTP header field value>"
                         }
                       ],
-                      "body": "<resource model body>",
-                      "schema": "<resource model schema>"
+                      "bodyAsset": {
+                        "asset": "<resource model body>"
+                      },
+                      "schemaAsset": {
+                        "asset": "<resource model schema>"
+                      }
                     }
                   ]
                 }
@@ -714,7 +752,7 @@ For the [API Blueprint Source Map](#source-map-description)
 
 The `snowcrash` [command-line tool](https://github.com/apiaryio/snowcrash#snow-crash-command-line-tool) supports serialization of [API Blueprint AST](https://github.com/apiaryio/snowcrash/blob/master/src/Blueprint.h) via the `--format` option.
 
-Similarily, it also supports serialization of [API Blueprint Source Map](https://github.com/apiaryio/snowcrash/blob/master/src/BlueprintSourcemap.h) via the `--format` option if and only is the `-s` is present.
+Similarly, it also supports serialization of [API Blueprint Source Map](https://github.com/apiaryio/snowcrash/blob/master/src/BlueprintSourcemap.h) via the `--format` option if and only is the `-s` is present.
 
 ## Related Media Types
 
@@ -724,22 +762,35 @@ Similarily, it also supports serialization of [API Blueprint Source Map](https:/
 
 MIT License. See the [LICENSE](LICENSE) file.
 
+<!-- API Blueprint AST -->
 
 [parsing media types]: Parse%20Result.md
+
+<!-- MSON -->
 
 [MSON]: https://github.com/apiaryio/mson
 [MSON AST]: https://github.com/apiaryio/mson-ast
 [MSON Named Type]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#22-named-types
 [MSON Named Types]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#22-named-types
 
+<!-- MSON AST -->
+
 [Named Type]: https://github.com/apiaryio/mson-ast#named-type
 [Type Name]: https://github.com/apiaryio/mson-ast#type-name
 [Type Definition]: https://github.com/apiaryio/mson-ast#type-definition
 [Type Section]: https://github.com/apiaryio/mson-ast#type-section
 
+[API Blueprint asset]: https://github.com/apiaryio/api-blueprint/blob/master/Glossary%20of%20Terms.md#asset
+
+<!-- API Blueprint Attributes -->
+
 [Attribute section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-attributes-section
 [Resource section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-resource-section
 
+<!-- Document anchors -->
+
+[Asset]: #asset
 [Attributes]: #attributes
 [Data Structure]: #data-structure
 [Data Structures]: #data-structures
+

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Following is the description of API Blueprint AST media types using the [MSON](h
 + `name` (string) - Name of the API
 + `description` (string) - Top-level description of the API in Markdown (`.raw`) or HTML (`.html`)
 + `resourceGroups` (array[[Resource Group](#resource-group)])
-+ `dataStructures` (array[[Data Structures][]]) 
++ `dataStructures` (array[[Data Structures][]])
 
 ### Resource Group
 
@@ -116,13 +116,13 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
 An [API Blueprint asset][].
 
 #### Properties
-+ `source` (string) 
++ `source` (string)
 
     The Asset in its textual representation as written in the source API Blueprint
 
 + `resolved` (string)
 
-    Asset in its textual form as resolved by parser's subsequent tooling. For example, generated from a [Data Structure][] description or by fetching the asset from an URL. 
+    Asset in its textual form as resolved by parser's subsequent tooling. For example, generated from a [Data Structure][] description or by fetching the asset from an URL.
 
 ### Parameter
 
@@ -162,15 +162,13 @@ A reference object which is used whenever there is a reference to a [Resource Mo
 
 Data structure definition as written in an API Blueprint [Attributes section][Attribute section].
 
-> **Note:** The `name` property of the [Data Structure][]'s `type` property is only present when the respective [Attribute section][] defines an MSON named type, such as in the context of the [Resource section][]. Otherwise (in the case of a Payload, Action or an unnamed Resource) the Attributes section is considered to be anonymous named type.
-
 ### Data Structure
 
 Definition of an [MSON][] data structure.
 
-> **NOTE:** Properties of this object may use some types defined in the [MSON AST][]. 
+> **NOTE:** Properties of this object may use some types defined in the [MSON AST][].
 
-#### Properties 
+#### Properties
 + `source` ([Named Type][]) - The data structure as described in the source API Blueprint
 
 + `resolved` ([Named Type][])

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Definition of the respective data structure attributes as described using the [M
 > **NOTE:** Properties of this object may use types defined in [MSON AST][]. 
 
 #### Properties
+
 + `name` ([Type Name][]) 
 
     Name of the type being defined, see MSON AST's [Type Name][].
@@ -349,6 +350,11 @@ For the [API Blueprint Source Map](#source-map-description)
               ]
             }
           ],
+          "attributes": {
+            "name": <MSON Type Name>,
+            "base": <MSON Type Definition>,
+            "sections": [ <MSON Type Section> ]
+          },
           "actions": [
             {
               "name": "<action name>",
@@ -369,6 +375,10 @@ For the [API Blueprint Source Map](#source-map-description)
                   ]
                 }
               ],
+              "attributes": {
+                "base": <MSON Type Definition>,
+                "sections": [ <MSON Type Section> ]
+              }, 
               "examples": [
                 {
                   "name": "<transaction example name>",
@@ -383,6 +393,10 @@ For the [API Blueprint Source Map](#source-map-description)
                           "value": "<HTTP header field value>"
                         }
                       ],
+                      "attributes": {
+                        "base": <MSON Type Definition>,
+                        "sections": [ <MSON Type Section> ]
+                      },
                       "body": "<request body>",
                       "schema": "<request schema>"
                     }
@@ -397,6 +411,10 @@ For the [API Blueprint Source Map](#source-map-description)
                           "value": "<HTTP header field value>"
                         }
                       ],
+                      "attributes": {
+                        "base": <MSON Type Definition>,
+                        "sections": [ <MSON Type Section> ]
+                      },
                       "body": "<response body>",
                       "schema": "<response schema>"
                     }
@@ -698,6 +716,12 @@ resourceGroups:
       values:
       - value: "<enum element>"
 
+    attributes:
+      name: <MSON Type Name>
+      base: <MSON Type Definition>
+      sections:
+        - <MSON Type Section>
+
     actions:
     - name: "<action name>"
       description: "<action description>"
@@ -713,6 +737,11 @@ resourceGroups:
         values:
         - value: "<enum element>"
 
+      attributes:
+        base: <MSON Type Definition>
+        sections:
+          - <MSON Type Section>
+
       examples:
       - name: "<transaction example name>"
         description: "<transaction example name>"
@@ -725,6 +754,11 @@ resourceGroups:
           - name: "<HTTP header field name>"
             value: "<HTTP header field value>"
 
+          attributes:
+            base: <MSON Type Definition>
+            sections:
+              - <MSON Type Section>
+
           body: "<request body>"
           schema: "<request schema>"
 
@@ -735,6 +769,11 @@ resourceGroups:
           headers:
           - name: "<HTTP header field name>"
             value: "<HTTP header field value>"
+
+          attributes:
+            base: <MSON Type Definition>
+            sections:
+              - <MSON Type Section>
 
           body: "<response body>"
           schema: "<response schema>"

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ For the [API Blueprint Source Map](#source-map-description)
               }
             ],
             "attributes": {
-              "type": {
+              "source": {
                 "name": null,
                 "base": {
                   "typeSpecification": {
@@ -375,7 +375,7 @@ For the [API Blueprint Source Map](#source-map-description)
             }
           ],
           "attributes": {
-            "type": {
+            "source": {
               "name": {
                 "literal": "<resource name>"
               },
@@ -408,7 +408,7 @@ For the [API Blueprint Source Map](#source-map-description)
                 }
               ],
               "attributes": {
-                "type": {
+                "source": {
                   "name": null,
                   "base": {
                     "typeSpecification": {
@@ -433,7 +433,7 @@ For the [API Blueprint Source Map](#source-map-description)
                         }
                       ],
                       "attributes": {
-                        "type": {
+                        "source": {
                           "name": null,
                           "base": {
                             "typeSpecification": {
@@ -464,7 +464,7 @@ For the [API Blueprint Source Map](#source-map-description)
                         }
                       ],
                       "attributes": {
-                        "type": {
+                        "source": {
                           "name": null,
                           "base": {
                             "typeSpecification": {

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 
 + **Version**: 3.0
 + **Created**: 2013-08-30
-+ **Updated**: 2014-11-26
++ **Updated**: 2014-11-27
 
 ---
 
@@ -107,24 +107,22 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
 + `description` (string) - Description of the payload (`.raw` or `.html`)
 + `attributes` ([Attributes][]) - Description of the message-body attributes
 + `headers` (string) - Ordered array of HTTP headers that are expected to be transferred with HTTP message represented by this payload
-+ `bodyAsset` ([Asset][])
-
-    An entity body to be transferred with HTTP message represented by this payload.
-
-+ `schemaAsset` ([Asset][])
-
-    A validation schema for the entity body as defined in `bodyAsset`.
++ `assets`
+  + `body` ([Asset][]) - An entity body to be transferred with HTTP message represented by this payload
+  + `schema` ([Asset][]) - A validation schema for the entity body as defined in the `body`
 
 ### Asset
 
 An [API Blueprint asset][].
 
 #### Properties
-+ `asset` (string) - The Asset in its textual representation, as written in the source API Blueprint
++ `source` (string) 
 
-+ `resolvedAsset` (string)
+    The Asset in its textual representation as written in the source API Blueprint
 
-    `asset` property `string` as resolved by parser subsequent tooling. Usually created from a [Data Structure][] description or fetching the Asset from an URL. 
++ `resolved` (string)
+
+    Asset in its textual form as resolved by parser' subsequent tooling. For example, generated from a [Data Structure][] description or by fetching the asset from an URL. 
 
 ### Parameter
 
@@ -173,13 +171,11 @@ Definition of an [MSON][] data structure.
 > **NOTE:** Properties of this object may use some types defined in the [MSON AST][]. 
 
 #### Properties 
-+ `type` ([Named Type][]) - Data Structure as described in the source API Blueprint
++ `source` ([Named Type][]) - The data structure as described in the source API Blueprint
 
-+ `resolvedType` ([Named Type][])
++ `resolved` ([Named Type][])
 
-    `type` property [Named Type][] as resolved by parser subsequent tooling. Usually created by expanding MSON Type references.
-
-    If present, this subtree MUST be a super set of the `type` property sub tree.
+    The data structure as resolved by parser's subsequent tooling. Usually obtained by expanding MSON Type references.
 
 ### Data Structures
 
@@ -354,11 +350,13 @@ For the [API Blueprint Source Map](#source-map-description)
                 "sections": null
               }
             },
-            "bodyAsset": {
-              "asset": "<resource model body>"
-            },
-            "schemaAsset": {
-              "asset": "<resource model schema>"
+            "assets": {
+              "body": {
+                "source": "<resource model body>"
+              },
+              "schema": {
+                "source": "<resource model schema>"
+              }
             }
           },
           "parameters": [
@@ -445,11 +443,13 @@ For the [API Blueprint Source Map](#source-map-description)
                           "sections": null
                         }
                       },
-                      "bodyAsset": {
-                        "asset": "<request body>"
-                      },
-                      "schemaAsset": {
-                        "asset": "<request schema>"
+                      "assets": {
+                        "body": {
+                          "source": "<request body>"
+                        },
+                        "schema": {
+                          "source": "<request schema>"
+                        }
                       }
                     }
                   ],
@@ -474,11 +474,13 @@ For the [API Blueprint Source Map](#source-map-description)
                           "sections": null
                         }
                       },
-                      "bodyAsset": {
-                        "asset": "<response body>"
-                      },
-                      "schemaAsset": {
-                        "asset": "<response schema>"
+                      "assets": {
+                        "body": {
+                          "source": "<response body>"
+                        },
+                        "schema": {
+                          "source": "<response schema>"
+                        }
                       }
                     }
                   ]
@@ -507,11 +509,13 @@ For the [API Blueprint Source Map](#source-map-description)
                           "value": "<HTTP header field value>"
                         }
                       ],
-                      "bodyAsset": {
-                        "asset": "<resource model body>"
-                      },
-                      "schemaAsset": {
-                        "asset": "<resource model schema>"
+                      "assets": {
+                        "body": {
+                          "source": "<resource model body>"
+                        },
+                        "schema": {
+                          "source": "<resource model schema>"
+                        }
                       }
                     }
                   ]

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 
 ## Version
 
-+ **Version**: 2.1
++ **Version**: 3.0
 + **Created**: 2013-08-30
-+ **Updated**: 2014-10-07
++ **Updated**: 2014-11-24
 
 ---
 
@@ -37,6 +37,7 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 ---
 
 ## AST Description
+
 Following is the description of API Blueprint AST media types using the [MSON](https://github.com/apiaryio/mson) syntax. The description starts with the top-level blueprint object.
 
 ### Blueprint
@@ -72,6 +73,10 @@ Description of one resource, or a cluster of resources defined by its URI templa
 + `uriTemplate` (string) - URI Template as defined in [RFC6570](http://tools.ietf.org/html/rfc6570)
 + `model` ([Payload](#payload)) - [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection), a reusable payload representing the resource
 + `parameters` (array[[Parameter](#parameter)]) - Ordered array of URI parameters
++ `attributes` ([Attributes][]) - Description of the Resource attributes.
+
+    In the case of a Resource with `name`, this section represents [MSON Named Type][].
+
 + `actions` (array[[Action](#action)]) - Ordered array of actions available on the resource each defining at least one complete HTTP transaction
 
 ### Action
@@ -84,6 +89,7 @@ An HTTP transaction (a request-response transaction). Actions are specified by a
 + `description` (string) - Description of the Action (`.raw` or `.html`)
 + `method` (string) - HTTP request method defining the action
 + `parameters` (array[[Parameter](#parameter)]) - Ordered array of resource's URI parameters descriptions specific to this action
++ `attributes` ([Attributes][]) - Description of the action input attributes – the default properties of the request message-body.
 + `examples` (array[[Transaction Example](#transaction-example)]) - Ordered array of HTTP transaction [examples](#example-section) for the relevant HTTP request method
 
 ### Payload
@@ -102,6 +108,7 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
 
 + `reference` ([Reference](#reference)) - Present if and only if a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) is present in the payload and it has been resolved correctly
 + `description` (string) - Description of the payload (`.raw` or `.html`)
++ `attributes` ([Attributes][]) - Description of the message-body attributes
 + `headers` (string) - Ordered array of HTTP headers that are expected to be transferred with HTTP message represented by this payload
 + `body` (string) - An entity body to be transferred with HTTP message represented by this payload
 + `schema` (string) - A validation schema for the entity body as defined in `body`
@@ -139,6 +146,36 @@ A reference object which is used whenever there is a reference to a [Resource Mo
 #### Properties
 
 + `id` (string) - The identifier (name) of the reference
+
+### Attributes
+
+Definition of the respective data structure attributes as described using the [MSON][] syntax.
+
+> **NOTE:** Properties of this object may use types defined in [MSON AST][]. 
+
+#### Properties
++ `name` ([Type Name][]) 
+
+    Name of the type being defined, see MSON AST's [Type Name][].
+
+    This property is only present when the [Attribute section][] defines an MSON named type, such as in the context of the [Resource section][].
+
++ `base` ([Type Definition][])
+
+    Ancestor type as defined by the MSON AST's [Type Definition][].
+
++ `sections` (array[[Type Section][]])
+
+    Ordered list of type sections as defined by the MSON AST's [Type Section][].
+
+### Data Structures
+
+List of arbitrary data structures defined as [MSON Named Types][].
+
+#### Properties
+- `types` (array[[Named Type][]]) - Array of defined types
+
+---
 
 ## Source Map Description
 Following is the description of Source map media types using the [MSON](https://github.com/apiaryio/mson) syntax. The description starts with the top-level blueprint object.
@@ -959,3 +996,18 @@ MIT License. See the [LICENSE](LICENSE) file.
 
 
 [parsing media types]: Parse%20Result.md
+
+[MSON]: https://github.com/apiaryio/mson
+[MSON AST]: https://github.com/apiaryio/mson-ast
+[MSON Named Type]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#22-named-types
+[MSON Named Types]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#22-named-types
+
+[Named Type]: https://github.com/apiaryio/mson-ast#named-type
+[Type Name]: https://github.com/apiaryio/mson-ast#type-name
+[Type Definition]: https://github.com/apiaryio/mson-ast#type-definition
+[Type Section]: https://github.com/apiaryio/mson-ast#type-section
+
+[Attribute section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-attributes-section
+[Resource section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-resource-section
+
+[Attributes]: #attributes

--- a/README.md
+++ b/README.md
@@ -74,9 +74,6 @@ Description of one resource, or a cluster of resources defined by its URI templa
 + `model` ([Payload](#payload)) - [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection), a reusable payload representing the resource
 + `parameters` (array[[Parameter](#parameter)]) - Ordered array of URI parameters
 + `attributes` ([Attributes][]) - Description of the Resource attributes.
-
-    In the case of a Resource with `name`, this section represents [MSON Named Type][].
-
 + `actions` (array[[Action](#action)]) - Ordered array of actions available on the resource each defining at least one complete HTTP transaction
 
 ### Action
@@ -127,7 +124,7 @@ An [API Blueprint asset][].
 
 + `resolvedAsset` (string)
 
-    `asset` property `string` as resolved by parser harness or subsequent tooling. Usually created from a [Data Structure][] description or fetching the Asset from an URL. 
+    `asset` property `string` as resolved by parser subsequent tooling. Usually created from a [Data Structure][] description or fetching the Asset from an URL. 
 
 ### Parameter
 
@@ -180,7 +177,7 @@ Definition of an [MSON][] data structure.
 
 + `resolvedType` ([Named Type][])
 
-    `type` property [Named Type][] as resolved by parser harness or subsequent tooling. Usually created by expanding Type references.
+    `type` property [Named Type][] as resolved by parser subsequent tooling. Usually created by expanding MSON Type references.
 
     If present, this subtree MUST be a super set of the `type` property sub tree.
 
@@ -756,18 +753,11 @@ Similarly, it also supports serialization of [API Blueprint Source Map](https://
 
 MIT License. See the [LICENSE](LICENSE) file.
 
-<!-- API Blueprint AST -->
-
 [parsing media types]: Parse%20Result.md
-
-<!-- MSON -->
 
 [MSON]: https://github.com/apiaryio/mson
 [MSON AST]: https://github.com/apiaryio/mson-ast
 [MSON Named Type]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#22-named-types
-[MSON Named Types]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#22-named-types
-
-<!-- MSON AST -->
 
 [Named Type]: https://github.com/apiaryio/mson-ast#named-type
 [Type Name]: https://github.com/apiaryio/mson-ast#type-name
@@ -776,15 +766,10 @@ MIT License. See the [LICENSE](LICENSE) file.
 
 [API Blueprint asset]: https://github.com/apiaryio/api-blueprint/blob/master/Glossary%20of%20Terms.md#asset
 
-<!-- API Blueprint Attributes -->
-
 [Attribute section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-attributes-section
 [Resource section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-resource-section
 
-<!-- Document anchors -->
-
 [Asset]: #asset
-[Attributes]: #attributes
+[Attributes]: ##attributes-data-structure
 [Data Structure]: #data-structure
 [Data Structures]: #data-structures
-

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 
 + **Version**: 3.0
 + **Created**: 2013-08-30
-+ **Updated**: 2014-12-16
++ **Updated**: 2014-12-24
 
 ---
 
@@ -28,7 +28,6 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 + [AST Description](#ast-description)
 + [Source map Description](#source-map-description)
 + [Media Types](#media-types)
-+ [Keys description](#keys-description)
 + [Example: JSON serialization](#example-json-serialization)
 + [Serialization in Snow Crash](#serialization-in-snow-crash)
 + [Serialized Parsing Result Media Types][parsing media types]
@@ -37,9 +36,9 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 
 ## AST Description
 
-Following is the description of API Blueprint AST media types using the [MSON](https://github.com/apiaryio/mson) syntax. The description starts with the top-level blueprint object.
+Following is the description of API Blueprint AST media types using the [MSON][] syntax. The description starts with the top-level blueprint object.
 
-### Blueprint
+### Blueprint (object)
 
 + `_version` (string) - Version of the AST Serialization as [defined](#version) in this document
 + `metadata` (array) - Ordered array of API Blueprint [metadata](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#MetadataSection)
@@ -49,10 +48,15 @@ Following is the description of API Blueprint AST media types using the [MSON](h
 
 + `name` (string) - Name of the API
 + `description` (string) - Top-level description of the API in Markdown (`.raw`) or HTML (`.html`)
-+ `resourceGroups` (array[[Resource Group](#resource-group)])
-+ `dataStructures` (array[[Data Structures][]])
++ `sections` (array[[Section][]]) - Ordered array of sections
++ `resourceGroups` (array[[Resource Group][]]) - **Deprecated**
 
-### Resource Group
+### Section (enum)
+
++ ([Resource Group][])
++ ([Data Structures][])
+
+### Resource Group (object)
 
 Logical group of resources.
 
@@ -60,9 +64,9 @@ Logical group of resources.
 
 + `name` (string) - Name of the Resource Group
 + `description` (string) - Description of the Resource Group (`.raw` or `.html`)
-+ `resources` (array[[Resource](#resource)]) - Ordered array of the respective resources belonging to the Resource Group
++ `resources` (array[[Resource][]]) - Ordered array of the respective resources belonging to the Resource Group
 
-### Resource
+### Resource (object)
 
 Description of one resource, or a cluster of resources defined by its URI template.
 
@@ -71,12 +75,12 @@ Description of one resource, or a cluster of resources defined by its URI templa
 + `name` (string) - Name of the Resource
 + `description` (string) - Description of the Resource (`.raw` or `.html`)
 + `uriTemplate` (string) - URI Template as defined in [RFC6570](http://tools.ietf.org/html/rfc6570)
-+ `model` ([Payload](#payload)) - [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection), a reusable payload representing the resource
-+ `parameters` (array[[Parameter](#parameter)]) - Ordered array of URI parameters
++ `model` ([Payload][]) - [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection), a reusable payload representing the resource
++ `parameters` (array[[Parameter][]]) - Ordered array of URI parameters
 + `attributes` ([Attributes][]) - Description of the Resource attributes.
-+ `actions` (array[[Action](#action)]) - Ordered array of actions available on the resource each defining at least one complete HTTP transaction
++ `actions` (array[[Action][]]) - Ordered array of actions available on the resource each defining at least one complete HTTP transaction
 
-### Action
+### Action (object)
 
 An HTTP transaction (a request-response transaction). Actions are specified by an HTTP request method within a resource.
 
@@ -85,11 +89,11 @@ An HTTP transaction (a request-response transaction). Actions are specified by a
 + `name` (string) - Name of the Action
 + `description` (string) - Description of the Action (`.raw` or `.html`)
 + `method` (string) - HTTP request method defining the action
-+ `parameters` (array[[Parameter](#parameter)]) - Ordered array of resource's URI parameters descriptions specific to this action
++ `parameters` (array[[Parameter][]]) - Ordered array of resource's URI parameters descriptions specific to this action
 + `attributes` ([Attributes][]) - Description of the action input attributes – the default properties of the request message-body.
-+ `examples` (array[[Transaction Example](#transaction-example)]) - Ordered array of HTTP transaction [examples](#example-section) for the relevant HTTP request method
++ `examples` (array[[Transaction Example][]]) - Ordered array of HTTP transaction [examples](#example-section) for the relevant HTTP request method
 
-### Payload
+### Payload (object)
 
 An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master/Glossary%20of%20Terms.md#payload).
 
@@ -103,7 +107,7 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
     + **request** payload: name of the request, if any
     + **response** payload: HTTP status code
 
-+ `reference` ([Reference](#reference)) - Present if and only if a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) is present in the payload and it has been resolved correctly
++ `reference` ([Reference][]) - Present if and only if a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) is present in the payload and it has been resolved correctly
 + `description` (string) - Description of the payload (`.raw` or `.html`)
 + `attributes` ([Attributes][]) - Description of the message-body attributes
 + `headers` (string) - Ordered array of HTTP headers that are expected to be transferred with HTTP message represented by this payload
@@ -123,11 +127,12 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
   + `body` ([Asset][]) - An entity body to be transferred with HTTP message represented by this payload
   + `schema` ([Asset][]) - A validation schema for the entity body as defined in the `body`
 
-### Asset
+### Asset (object)
 
 An [API Blueprint asset][].
 
 #### Properties
+
 + `source` (string)
 
     The Asset in its textual representation as written in the source API Blueprint
@@ -136,22 +141,22 @@ An [API Blueprint asset][].
 
     Asset in its textual form as resolved by parser's subsequent tooling. For example, generated from a [Data Structure][] description or by fetching the asset from an URL.
 
-### Parameter
+### Parameter (object)
 
 Description of one URI template parameter.
 
 #### Properties
 
-- `description` (string) - Description of the parameter (`.raw` or `.html`)
-- `type` (string) - An arbitrary type of the parameter (a string)
-- `required` (string) - Boolean flag denoting whether the parameter is required (true) or not (false)
-- `default` (string) - A default value of the parameter (a value assumed when the parameter is not specified)
-- `example` (string) - An example value of the parameter
-- `values` (array) - An array enumerating possible parameter values
-    - (object)
-        - `value` (string) - Value choice of for the parameter
++ `description` (string) - Description of the parameter (`.raw` or `.html`)
++ `type` (string) - An arbitrary type of the parameter (a string)
++ `required` (string) - Boolean flag denoting whether the parameter is required (true) or not (false)
++ `default` (string) - A default value of the parameter (a value assumed when the parameter is not specified)
++ `example` (string) - An example value of the parameter
++ `values` (array) - An array enumerating possible parameter values
+    + (object)
+        + `value` (string) - Value choice of for the parameter
 
-### Transaction Example
+### Transaction Example (object)
 
 An HTTP transaction example with expected HTTP message request and response payload(s).
 
@@ -159,10 +164,10 @@ An HTTP transaction example with expected HTTP message request and response payl
 
 + `name` (string) - Name of the Transaction Example
 + `description` (string) - Description of the Transaction Example (`.raw` or `.html`)
-+ `requests` (array[[Payload](#payload)]) - Ordered array of example transaction request payloads
-+ `responses` (array[[Payload](#payload)]) - Ordered array of example transaction response payloads
++ `requests` (array[[Payload][]]) - Ordered array of example transaction request payloads
++ `responses` (array[[Payload][]]) - Ordered array of example transaction response payloads
 
-### Reference
+### Reference (object)
 
 A reference object which is used whenever there is a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection).
 
@@ -174,24 +179,25 @@ A reference object which is used whenever there is a reference to a [Resource Mo
 
 Data structure definition as written in an API Blueprint [Attributes section][Attribute section].
 
-### Data Structure
+### Data Structure (object)
 
 Definition of an [MSON][] data structure.
 
 > **NOTE:** Properties of this object may use some types defined in the [MSON AST][].
 
 #### Properties
-+ `source` ([Named Type][]) - The data structure as described in the source API Blueprint
 
++ `source` ([Named Type][]) - The data structure as described in the source API Blueprint
 + `resolved` ([Named Type][])
 
     The data structure as resolved by parser's subsequent tooling. Usually obtained by expanding MSON Type references.
 
-### Data Structures
+### Data Structures (object)
 
 List of arbitrary data structures defined in API Blueprint.
 
 #### Properties
+
 + `types` (array[[Data Structure][]]) - Array of defined data structures
 
 ---
@@ -331,7 +337,7 @@ For the [API Blueprint Source Map](#source-map-description)
   ],
   "name": "<API name>",
   "description": "<API description>",
-  "resourceGroups": [
+  "sections": [
     {
       "name": "<resource group name>",
       "description": "<resource group description>",
@@ -763,6 +769,8 @@ Similarly, it also supports serialization of [API Blueprint Source Map](https://
 
 - [**Serialized Parsing Result Media Types**][parsing media types] - Media types for the serialization of complete parsing results (including warnings and errors)
 
+---
+
 ## License
 
 MIT License. See the [LICENSE](LICENSE) file.
@@ -783,7 +791,16 @@ MIT License. See the [LICENSE](LICENSE) file.
 [Attribute section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-attributes-section
 [Resource section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-resource-section
 
-[Asset]: #asset
+[Blueprint]: #blueprint-object
+[Section]: #section-enum
+[Resource Group]: #resource-group-object
+[Resource]: #resource-object
+[Action]: #action-object
+[Payload]: #payload-object
+[Asset]: #asset-object
+[Parameter]: #parameter-object
+[Transaction Example]: #transaction-example-object
+[Reference]: #reference-object
 [Attributes]: #attributes-data-structure
-[Data Structure]: #data-structure
-[Data Structures]: #data-structures
+[Data Structure]: #data-structure-object
+[Data Structures]: #data-structures-object

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ An [API Blueprint asset][].
 
 + `resolved` (string)
 
-    Asset in its textual form as resolved by parser' subsequent tooling. For example, generated from a [Data Structure][] description or by fetching the asset from an URL. 
+    Asset in its textual form as resolved by parser's subsequent tooling. For example, generated from a [Data Structure][] description or by fetching the asset from an URL. 
 
 ### Parameter
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 
 + **Version**: 3.0
 + **Created**: 2013-08-30
-+ **Updated**: 2014-11-27
++ **Updated**: 2014-12-16
 
 ---
 
@@ -107,6 +107,18 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
 + `description` (string) - Description of the payload (`.raw` or `.html`)
 + `attributes` ([Attributes][]) - Description of the message-body attributes
 + `headers` (string) - Ordered array of HTTP headers that are expected to be transferred with HTTP message represented by this payload
++ `body` (string) - **Deprecated**
+
+    An entity body to be transferred with HTTP message represented by this payload
+
+    Note this property is **deprecated** and will be removed in a future. Use `assets/body/source` instead.
+
++ `schema` (string) - **Deprecated**
+
+    A validation schema for the entity body as defined in `body`.
+
+    Note this property is **deprecated** and will be removed in a future. Use `assets/schema/source` instead.
+
 + `assets`
   + `body` ([Asset][]) - An entity body to be transferred with HTTP message represented by this payload
   + `schema` ([Asset][]) - A validation schema for the entity body as defined in the `body`

--- a/README.md
+++ b/README.md
@@ -770,6 +770,6 @@ MIT License. See the [LICENSE](LICENSE) file.
 [Resource section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-resource-section
 
 [Asset]: #asset
-[Attributes]: ##attributes-data-structure
+[Attributes]: #attributes-data-structure
 [Data Structure]: #data-structure
 [Data Structures]: #data-structures

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Following is the description of API Blueprint AST media types using the [MSON](h
 + `name` (string) - Name of the API
 + `description` (string) - Top-level description of the API in Markdown (`.raw`) or HTML (`.html`)
 + `resourceGroups` (array[[Resource Group](#resource-group)])
++ `dataStructures` (array[[Data Structures][]]) 
 
 ### Resource Group
 
@@ -988,7 +989,7 @@ Similarily, it also supports serialization of [API Blueprint Source Map](https:/
 
 ## Related Media Types
 
-- [**Serialized Parsing Result Media Types**][parsing media types] - Media types for the serialization of complete parsing results (including warnigns and errors)
+- [**Serialized Parsing Result Media Types**][parsing media types] - Media types for the serialization of complete parsing results (including warnings and errors)
 
 ## License
 
@@ -1011,3 +1012,4 @@ MIT License. See the [LICENSE](LICENSE) file.
 [Resource section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-resource-section
 
 [Attributes]: #attributes
+[Data Structures]: #data-structures


### PR DESCRIPTION
We have deprecated `resourceGroups` and added `sections` to the top-level blueprint object. A section can either be a `Resource Group` or `Data Structures`.

**Should be merged only after #15 is merged.**