### PR TITLE
Changes to Source Map description after recent AST changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 
 + **Version**: 3.0
 + **Created**: 2013-08-30
-+ **Updated**: 2014-12-16
++ **Updated**: 2014-12-24
 
 ---
 
@@ -28,7 +28,6 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 + [AST Description](#ast-description)
 + [Source map Description](#source-map-description)
 + [Media Types](#media-types)
-+ [Keys description](#keys-description)
 + [Example: JSON serialization](#example-json-serialization)
 + [Serialization in Snow Crash](#serialization-in-snow-crash)
 + [Serialized Parsing Result Media Types][parsing media types]
@@ -37,9 +36,9 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 
 ## AST Description
 
-Following is the description of API Blueprint AST media types using the [MSON](https://github.com/apiaryio/mson) syntax. The description starts with the top-level blueprint object.
+Following is the description of API Blueprint AST media types using the [MSON][] syntax. The description starts with the top-level blueprint object.
 
-### Blueprint
+### Blueprint (object)
 
 + `_version` (string) - Version of the AST Serialization as [defined](#version) in this document
 + `metadata` (array) - Ordered array of API Blueprint [metadata](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#MetadataSection)
@@ -49,10 +48,15 @@ Following is the description of API Blueprint AST media types using the [MSON](h
 
 + `name` (string) - Name of the API
 + `description` (string) - Top-level description of the API in Markdown (`.raw`) or HTML (`.html`)
-+ `resourceGroups` (array[[Resource Group](#resource-group)])
-+ `dataStructures` (array[[Data Structures][]])
++ `section` (array[[Section][]]) - Ordered array of sections
++ `resourceGroups` (array[[Resource Group][]]) - **Deprecated**
 
-### Resource Group
+### Section (enum)
+
++ ([Resource Group][])
++ ([Data Structures][])
+
+### Resource Group (object)
 
 Logical group of resources.
 
@@ -60,9 +64,9 @@ Logical group of resources.
 
 + `name` (string) - Name of the Resource Group
 + `description` (string) - Description of the Resource Group (`.raw` or `.html`)
-+ `resources` (array[[Resource](#resource)]) - Ordered array of the respective resources belonging to the Resource Group
++ `resources` (array[[Resource][]]) - Ordered array of the respective resources belonging to the Resource Group
 
-### Resource
+### Resource (object)
 
 Description of one resource, or a cluster of resources defined by its URI template.
 
@@ -71,12 +75,12 @@ Description of one resource, or a cluster of resources defined by its URI templa
 + `name` (string) - Name of the Resource
 + `description` (string) - Description of the Resource (`.raw` or `.html`)
 + `uriTemplate` (string) - URI Template as defined in [RFC6570](http://tools.ietf.org/html/rfc6570)
-+ `model` ([Payload](#payload)) - [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection), a reusable payload representing the resource
-+ `parameters` (array[[Parameter](#parameter)]) - Ordered array of URI parameters
++ `model` ([Payload][]) - [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection), a reusable payload representing the resource
++ `parameters` (array[[Parameter][]]) - Ordered array of URI parameters
 + `attributes` ([Attributes][]) - Description of the Resource attributes.
-+ `actions` (array[[Action](#action)]) - Ordered array of actions available on the resource each defining at least one complete HTTP transaction
++ `actions` (array[[Action][]]) - Ordered array of actions available on the resource each defining at least one complete HTTP transaction
 
-### Action
+### Action (object)
 
 An HTTP transaction (a request-response transaction). Actions are specified by an HTTP request method within a resource.
 
@@ -85,11 +89,11 @@ An HTTP transaction (a request-response transaction). Actions are specified by a
 + `name` (string) - Name of the Action
 + `description` (string) - Description of the Action (`.raw` or `.html`)
 + `method` (string) - HTTP request method defining the action
-+ `parameters` (array[[Parameter](#parameter)]) - Ordered array of resource's URI parameters descriptions specific to this action
++ `parameters` (array[[Parameter][]]) - Ordered array of resource's URI parameters descriptions specific to this action
 + `attributes` ([Attributes][]) - Description of the action input attributes – the default properties of the request message-body.
-+ `examples` (array[[Transaction Example](#transaction-example)]) - Ordered array of HTTP transaction [examples](#example-section) for the relevant HTTP request method
++ `examples` (array[[Transaction Example][]]) - Ordered array of HTTP transaction [examples](#example-section) for the relevant HTTP request method
 
-### Payload
+### Payload (object)
 
 An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master/Glossary%20of%20Terms.md#payload).
 
@@ -103,7 +107,7 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
     + **request** payload: name of the request, if any
     + **response** payload: HTTP status code
 
-+ `reference` ([Reference](#reference)) - Present if and only if a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) is present in the payload and it has been resolved correctly
++ `reference` ([Reference][]) - Present if and only if a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) is present in the payload and it has been resolved correctly
 + `description` (string) - Description of the payload (`.raw` or `.html`)
 + `attributes` ([Attributes][]) - Description of the message-body attributes
 + `headers` (string) - Ordered array of HTTP headers that are expected to be transferred with HTTP message represented by this payload
@@ -123,11 +127,12 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
   + `body` ([Asset][]) - An entity body to be transferred with HTTP message represented by this payload
   + `schema` ([Asset][]) - A validation schema for the entity body as defined in the `body`
 
-### Asset
+### Asset (object)
 
 An [API Blueprint asset][].
 
 #### Properties
+
 + `source` (string)
 
     The Asset in its textual representation as written in the source API Blueprint
@@ -136,22 +141,22 @@ An [API Blueprint asset][].
 
     Asset in its textual form as resolved by parser's subsequent tooling. For example, generated from a [Data Structure][] description or by fetching the asset from an URL.
 
-### Parameter
+### Parameter (object)
 
 Description of one URI template parameter.
 
 #### Properties
 
-- `description` (string) - Description of the parameter (`.raw` or `.html`)
-- `type` (string) - An arbitrary type of the parameter (a string)
-- `required` (string) - Boolean flag denoting whether the parameter is required (true) or not (false)
-- `default` (string) - A default value of the parameter (a value assumed when the parameter is not specified)
-- `example` (string) - An example value of the parameter
-- `values` (array) - An array enumerating possible parameter values
-    - (object)
-        - `value` (string) - Value choice of for the parameter
++ `description` (string) - Description of the parameter (`.raw` or `.html`)
++ `type` (string) - An arbitrary type of the parameter (a string)
++ `required` (string) - Boolean flag denoting whether the parameter is required (true) or not (false)
++ `default` (string) - A default value of the parameter (a value assumed when the parameter is not specified)
++ `example` (string) - An example value of the parameter
++ `values` (array) - An array enumerating possible parameter values
+    + (object)
+        + `value` (string) - Value choice of for the parameter
 
-### Transaction Example
+### Transaction Example (object)
 
 An HTTP transaction example with expected HTTP message request and response payload(s).
 
@@ -159,10 +164,10 @@ An HTTP transaction example with expected HTTP message request and response payl
 
 + `name` (string) - Name of the Transaction Example
 + `description` (string) - Description of the Transaction Example (`.raw` or `.html`)
-+ `requests` (array[[Payload](#payload)]) - Ordered array of example transaction request payloads
-+ `responses` (array[[Payload](#payload)]) - Ordered array of example transaction response payloads
++ `requests` (array[[Payload][]]) - Ordered array of example transaction request payloads
++ `responses` (array[[Payload][]]) - Ordered array of example transaction response payloads
 
-### Reference
+### Reference (object)
 
 A reference object which is used whenever there is a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection).
 
@@ -174,24 +179,25 @@ A reference object which is used whenever there is a reference to a [Resource Mo
 
 Data structure definition as written in an API Blueprint [Attributes section][Attribute section].
 
-### Data Structure
+### Data Structure (object)
 
 Definition of an [MSON][] data structure.
 
 > **NOTE:** Properties of this object may use some types defined in the [MSON AST][].
 
 #### Properties
-+ `source` ([Named Type][]) - The data structure as described in the source API Blueprint
 
++ `source` ([Named Type][]) - The data structure as described in the source API Blueprint
 + `resolved` ([Named Type][])
 
     The data structure as resolved by parser's subsequent tooling. Usually obtained by expanding MSON Type references.
 
-### Data Structures
+### Data Structures (object)
 
 List of arbitrary data structures defined in API Blueprint.
 
 #### Properties
+
 + `types` (array[[Data Structure][]]) - Array of defined data structures
 
 ---
@@ -331,7 +337,7 @@ For the [API Blueprint Source Map](#source-map-description)
   ],
   "name": "<API name>",
   "description": "<API description>",
-  "resourceGroups": [
+  "sections": [
     {
       "name": "<resource group name>",
       "description": "<resource group description>",
@@ -763,6 +769,8 @@ Similarly, it also supports serialization of [API Blueprint Source Map](https://
 
 - [**Serialized Parsing Result Media Types**][parsing media types] - Media types for the serialization of complete parsing results (including warnings and errors)
 
+---
+
 ## License
 
 MIT License. See the [LICENSE](LICENSE) file.
@@ -783,7 +791,16 @@ MIT License. See the [LICENSE](LICENSE) file.
 [Attribute section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-attributes-section
 [Resource section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-resource-section
 
-[Asset]: #asset
+[Blueprint]: #blueprint-object
+[Section]: #section-enum
+[Resource Group]: #resource-group-object
+[Resource]: #resource-object
+[Action]: #action-object
+[Payload]: #payload-object
+[Asset]: #asset-object
+[Parameter]: #parameter-object
+[Transaction Example]: #transaction-example-object
+[Reference]: #reference-object
 [Attributes]: #attributes-data-structure
-[Data Structure]: #data-structure
-[Data Structures]: #data-structures
+[Data Structure]: #data-structure-object
+[Data Structures]: #data-structures-object

--- a/README.md
+++ b/README.md
@@ -203,102 +203,100 @@ List of arbitrary data structures defined in API Blueprint.
 ---
 
 ## Source Map Description
-Following is the description of Source map media types using the [MSON](https://github.com/apiaryio/mson) syntax. The description starts with the top-level blueprint object.
 
-### Source Map
+Following is the description of Source map media types using the [MSON][] syntax. The description starts with the top-level blueprint object.
 
-An example source map.
+### Source Map (array)
 
-- (array)
-  - (array)
-    - 1219 (number) - Zero-based index of the character position of the beginning of the source
-    - 30 (number) - Length of the source
-  - (array)
-    - 1261 (number)
-    - 175 (number)
+This contains the information about the characters positions in the source.
 
-### Blueprint Source Map
+#### Items
+- (array, fixed)
+    - *1219* (number) - Zero-based index of the character position of the beginning of the source
+    - *30* (number) - Length of the source
 
-Source map of the [Blueprint](#blueprint).
+### Blueprint Source Map (object)
+
+Source map of the [Blueprint][].
 
 #### Properties
 
-+ `metadata` (array[[Source Map](#source-map)]) - An array of source maps where each item in metadata has its own source map
-+ `name` ([Source Map](#source-map)) - Source map of API name
-+ `description` ([Source Map](#source-map)) - Source map of API description
-+ `resourceGroups` (array[[Resource Group Source Map](#resource-group-source-map)])
++ `metadata` (array[[Source Map][]]) - An array of source maps where each item in metadata has its own source map
++ `name` ([Source Map][]) - Source map of API name
++ `description` ([Source Map][]) - Source map of API description
++ `resourceGroups` (array[[Resource Group Source Map][]])
 
-### Resource Group Source Map
+### Resource Group Source Map (object)
 
-Source map of the [Resource Group](#resource-group).
-
-#### Properties
-
-+ `name` ([Source Map](#source-map)) - Source map of name of the Resource Group
-+ `description` ([Source Map](#source-map)) - Source map of description of the Resource Group
-+ `resources` (array[[Resource Source Map](#resource-source-map)]) - Ordered array of the respective resources belonging to the Resource Group
-
-### Resource Source Map
-
-Source map of the [Resource](#resource).
+Source map of the [Resource Group][].
 
 #### Properties
 
-+ `name` ([Source Map](#source-map)) - Source map of name of the Resource
-+ `description` ([Source Map](#source-map)) - Source map of description of the Resource
-+ `uriTemplate` ([Source Map](#source-map)) - Source map of URI Template
-+ `model` ([Payload Source map](#payload-source-map)) - [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection), a reusable payload representing the resource
-+ `parameters` (array[[Parameter Source Map](#parameter-source-map)]) - Ordered array of source maps of URI parameters
-+ `actions` (array[[Action Source Map](#action-source-map)]) - Ordered array of source maps of actions available on the resource each defining at least one complete HTTP transaction
++ `name` ([Source Map][]) - Source map of name of the Resource Group
++ `description` ([Source Map][]) - Source map of description of the Resource Group
++ `resources` (array[[Resource Source Map][]]) - Ordered array of the respective resources belonging to the Resource Group
 
-### Action Source Map
+### Resource Source Map (object)
 
-Source map of the [Action](#action).
+Source map of the [Resource][].
 
 #### Properties
 
-+ `name` ([Source Map](#source-map)) - Source map of name of the Action
-+ `description` ([Source Map](#source-map)) - Source map of description of the Action
-+ `method` ([Source Map](#source-map)) - Source map of HTTP request method defining the action
-+ `parameters` (array[[Parameter Source Map](#parameter-source-map)]) - Ordered array of source maps of resource's URI parameters descriptions specific to this action
-+ `examples` (array[[Transaction Example Source Map](#transaction-example-source-map)]) - Ordered array of source maps of HTTP transaction [examples](#example-section) for the relevant HTTP request method
++ `name` ([Source Map][]) - Source map of name of the Resource
++ `description` ([Source Map][]) - Source map of description of the Resource
++ `uriTemplate` ([Source Map][]) - Source map of URI Template
++ `model` ([Payload Source Map][]) - [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection), a reusable payload representing the resource
++ `parameters` (array[[Parameter Source Map][]]) - Ordered array of source maps of URI parameters
++ `actions` (array[[Action Source Map][]]) - Ordered array of source maps of actions available on the resource each defining at least one complete HTTP transaction
 
-### Payload Source Map
+### Action Source Map (object)
 
-Source map of [Payload](#payload). The source map of the payload is in fact the source map of the [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) when the reference is used.
-
-#### Properties
-
-+ `name` ([Source Map](#source-map)) - Source map of name of the payload
-+ `reference` ([Source Map](#source-map)) - Source map of the reference, present if and only if a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) is present in the payload and it has been resolved correctly
-+ `description` ([Source Map](#source-map)) - Source map of description of the payload
-+ `headers` (array[[Source Map](#source-map)]) - Ordered array of source maps of HTTP headers that are expected to be transferred with HTTP message represented by this payload. Each item in the header has it's own source map.
-+ `body` ([Source Map](#source-map)) - Source map of body to be transferred with HTTP message represented by this payload
-+ `schema` ([Source Map](#source-map)) - Source map of a validation schema for the entity body as defined in `body`
-
-### Parameter Source Map
-
-Source map of [Parameter](#parameter).
+Source map of the [Action][].
 
 #### Properties
 
-- `description` ([Source Map](#source-map)) - Source map of description of the parameter
-- `type` ([Source Map](#source-map)) - Source map of an arbitrary type of the parameter (a string)
-- `required` ([Source Map](#source-map)) - Source map of boolean flag denoting whether the parameter is required (true) or not (false)
-- `default` ([Source Map](#source-map)) - Source map of a default value of the parameter (a value assumed when the parameter is not specified)
-- `example` ([Source Map](#source-map)) - Source map of an example value of the parameter
-- `values` (array[[Source Map](#source-map)]) - Source map of an array enumerating possible parameter values. Each item has it's own source map.
++ `name` ([Source Map][]) - Source map of name of the Action
++ `description` ([Source Map][]) - Source map of description of the Action
++ `method` ([Source Map][]) - Source map of HTTP request method defining the action
++ `parameters` (array[[Parameter Source Map][]]) - Ordered array of source maps of resource's URI parameters descriptions specific to this action
++ `examples` (array[[Transaction Example Source Map][]]) - Ordered array of source maps of HTTP transaction [examples](#example-section) for the relevant HTTP request method
 
-### Transaction Example Source Map
+### Payload Source Map (object)
 
-Source map of [Transaction Example](#transaction-example).
+Source map of [Payload][]. The source map of the payload is in fact the source map of the [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) when the reference is used.
 
 #### Properties
 
-+ `name` ([Source Map](#source-map)) - Source map of name of the Transaction Example
-+ `description` ([Source Map](#source-map)) - Source map of description of the Transaction Example
-+ `requests` (array[[Payload Source Map](#payload-source-map)]) - Ordered array of source maps of example transaction request payloads
-+ `responses` (array[[Payload Source Map](#payload-source-map)]) - Ordered array of source maps of example transaction response payloads
++ `name` ([Source Map][]) - Source map of name of the payload
++ `reference` ([Source Map][]) - Source map of the reference, present if and only if a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) is present in the payload and it has been resolved correctly
++ `description` ([Source Map][]) - Source map of description of the payload
++ `headers` (array[[Source Map][]]) - Ordered array of source maps of HTTP headers that are expected to be transferred with HTTP message represented by this payload. Each item in the header has it's own source map.
++ `body` ([Source Map][]) - Source map of body to be transferred with HTTP message represented by this payload
++ `schema` ([Source Map][]) - Source map of a validation schema for the entity body as defined in `body`
+
+### Parameter Source Map (object)
+
+Source map of [Parameter][].
+
+#### Properties
+
++ `description` ([Source Map][]) - Source map of description of the parameter
++ `type` ([Source Map][]) - Source map of an arbitrary type of the parameter (a string)
++ `required` ([Source Map][]) - Source map of boolean flag denoting whether the parameter is required (true) or not (false)
++ `default` ([Source Map][]) - Source map of a default value of the parameter (a value assumed when the parameter is not specified)
++ `example` ([Source Map][]) - Source map of an example value of the parameter
++ `values` (array[[Source Map][]]) - Source map of an array enumerating possible parameter values. Each item has it's own source map.
+
+### Transaction Example Source Map (object)
+
+Source map of [Transaction Example][].
+
+#### Properties
+
++ `name` ([Source Map][]) - Source map of name of the Transaction Example
++ `description` ([Source Map][]) - Source map of description of the Transaction Example
++ `requests` (array[[Payload Source Map][]]) - Ordered array of source maps of example transaction request payloads
++ `responses` (array[[Payload Source Map][]]) - Ordered array of source maps of example transaction response payloads
 
 ---
 
@@ -804,3 +802,12 @@ MIT License. See the [LICENSE](LICENSE) file.
 [Attributes]: #attributes-data-structure
 [Data Structure]: #data-structure-object
 [Data Structures]: #data-structures-object
+
+[Source Map]: #source-map-array
+[Blueprint Source Map]: #blueprint-source-map-object
+[Resource Group Source Map]: #resource-group-source-map-object
+[Resource Source Map]: #resource-source-map-object
+[Action Source Map]: #action-source-map-object
+[Payload Source Map]: #payload-source-map-object
+[Parameter Source Map]: #parameter-source-map-object
+[Transaction Example Source Map]: #transaction-example-source-map-object

--- a/README.md
+++ b/README.md
@@ -224,7 +224,13 @@ Source map of the [Blueprint][].
 + `metadata` (array[[Source Map][]]) - An array of source maps where each item in metadata has its own source map
 + `name` ([Source Map][]) - Source map of API name
 + `description` ([Source Map][]) - Source map of API description
-+ `resourceGroups` (array[[Resource Group Source Map][]])
++ `sections` (array[[Section Source Map][]]) - Ordered array of source maps of sections
++ `resourceGroups` (array[[Resource Group Source Map][]]) - **Deprecated**
+
+### Section Source Map (enum)
+
++ ([Resource Group Source Map][])
++ ([Data Structures Source Map][])
 
 ### Resource Group Source Map (object)
 
@@ -247,6 +253,7 @@ Source map of the [Resource][].
 + `uriTemplate` ([Source Map][]) - Source map of URI Template
 + `model` ([Payload Source Map][]) - [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection), a reusable payload representing the resource
 + `parameters` (array[[Parameter Source Map][]]) - Ordered array of source maps of URI parameters
++ `attributes` ([Attributes Source Map][]) - Source map of attributes of the Resource
 + `actions` (array[[Action Source Map][]]) - Ordered array of source maps of actions available on the resource each defining at least one complete HTTP transaction
 
 ### Action Source Map (object)
@@ -259,6 +266,7 @@ Source map of the [Action][].
 + `description` ([Source Map][]) - Source map of description of the Action
 + `method` ([Source Map][]) - Source map of HTTP request method defining the action
 + `parameters` (array[[Parameter Source Map][]]) - Ordered array of source maps of resource's URI parameters descriptions specific to this action
++ `attributes` ([Attributes Source Map][]) - Source map of attributes of the Action
 + `examples` (array[[Transaction Example Source Map][]]) - Ordered array of source maps of HTTP transaction [examples](#example-section) for the relevant HTTP request method
 
 ### Payload Source Map (object)
@@ -270,9 +278,31 @@ Source map of [Payload][]. The source map of the payload is in fact the source m
 + `name` ([Source Map][]) - Source map of name of the payload
 + `reference` ([Source Map][]) - Source map of the reference, present if and only if a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) is present in the payload and it has been resolved correctly
 + `description` ([Source Map][]) - Source map of description of the payload
-+ `headers` (array[[Source Map][]]) - Ordered array of source maps of HTTP headers that are expected to be transferred with HTTP message represented by this payload. Each item in the header has it's own source map.
-+ `body` ([Source Map][]) - Source map of body to be transferred with HTTP message represented by this payload
-+ `schema` ([Source Map][]) - Source map of a validation schema for the entity body as defined in `body`
++ `attributes` ([Attributes Source Map][]) - Source map of attributes of the Payload
++ `headers` (array[[Source Map][]]) - Ordered array of source maps of HTTP headers that are expected to be transferred with HTTP message represent
++ `body` ([Source Map][]) - **Deprecated**
+
+    Source map of body to be transferred with HTTP message represented by this payload
+
+    Note this property is **deprecated** and will be removed in a future. Use `assets/body/source` instead.
+
++ `schema` ([Source Map][]) - **Deprecated**
+
+    Source map of a validation schema for the entity body as defined in `body`.
+
+    Note this property is **deprecated** and will be removed in a future. Use `assets/schema/source` instead.
+
++ `assets`
+  + `body` ([Asset Source Map][]) - Source map of body to be transferred with HTTP message represented by this payload
+  + `schema` ([Asset Source Map][]) - Source map of a validation schema for the entity body as defined in the `body`
+
+### Asset Source Map (object)
+
+Source map of [Asset][]
+
+#### Properties
+
++ `source` ([Source Map][]) - Source map of the asset in its textual representation as written in the source API Blueprint
 
 ### Parameter Source Map (object)
 
@@ -297,6 +327,26 @@ Source map of [Transaction Example][].
 + `description` ([Source Map][]) - Source map of description of the Transaction Example
 + `requests` (array[[Payload Source Map][]]) - Ordered array of source maps of example transaction request payloads
 + `responses` (array[[Payload Source Map][]]) - Ordered array of source maps of example transaction response payloads
+
+### Attributes Source Map ([Data Structure Source Map][])
+
+Source map of [Attributes][]
+
+### Data Structure Source Map (object)
+
+Source map of [Data Structure][]
+
+#### Properties
+
++ `source` ([Named Type Source Map][]) - Source map of the data structure as described in the source API Blueprint
+
+### Data Structures Source Map (object)
+
+Source map of [Data Structures][]
+
+#### Properties
+
++ `types` (array[[Data Structure Source Map][]]) - Array of defined data structure source maps
 
 ---
 
@@ -559,7 +609,7 @@ For the [API Blueprint Source Map](#source-map-description)
   "description": [
     [52, 19]
   ],
-  "resourceGroups": [
+  "sections": [
     {
       "name": [
         [71, 30]
@@ -805,9 +855,14 @@ MIT License. See the [LICENSE](LICENSE) file.
 
 [Source Map]: #source-map-array
 [Blueprint Source Map]: #blueprint-source-map-object
+[Section Source Map]: #section-source-map-enum
 [Resource Group Source Map]: #resource-group-source-map-object
 [Resource Source Map]: #resource-source-map-object
 [Action Source Map]: #action-source-map-object
 [Payload Source Map]: #payload-source-map-object
+[Asset Source Map]: #asset-source-map-object
 [Parameter Source Map]: #parameter-source-map-object
 [Transaction Example Source Map]: #transaction-example-source-map-object
+[Attributes Source Map]: #attributes-source-map-data-structure-source-map
+[Data Structure Source Map]: #data-structure-source-map-object
+[Data Structures Source Map]: #data-structures-source-map-object


### PR DESCRIPTION
Includes source maps for `Section`, `Attributes`, `Data Structure`, `Data Structures`, `Asset`