### PR TITLE
[Parameter] Document the name attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Description of one URI template parameter.
 
 #### Properties
 
+- `name` (string) - Name of the parameter
 - `description` (string) - Description of the parameter (`.raw` or `.html`)
 - `type` (string) - An arbitrary type of the parameter (a string)
 - `required` (string) - Boolean flag denoting whether the parameter is required (true) or not (false)


### PR DESCRIPTION
The `name` attribute of `Parameter` seems to be missing, it's in the markdown specification along with the AST generated via Snowcrash.

#### API Blueprint Specification

```markdown
+ <parameter name> = `<default value>` (required | optional , <type>, `<example value>`) ... <description>
```

Where

```markdown
<parameter name> is the parameter name as written in Resource Section's URI (e.g. "id").
```

#### Snowcrash

You can see that it's serialised into the JSON AST from https://github.com/apiaryio/snowcrash/blob/master/src/SerializeJSON.cc#L372-374.