### PR TITLE
Improving attributes-description without any JDOM

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Following is the definition of API Blueprint AST media types using the [MSON](ht
 + `name` (string) - Name of the API
 + `description` (string) - Top-level description of the API in Markdown (`.raw`) or HTML (`.html`)
 + `resourceGroups` (array[[Resource Group][]])
-+ `dataStructures` (array[[Data Structures][]])
++ `dataStructures` (array[[Data Structure][]]) - List of arbitrary data structures defined in API Blueprint
 
 ### Resource Group (object)
 Logical group of resources.
@@ -162,12 +162,6 @@ Definition of an [MSON][] data structure.
 + `resolved` ([Named Type][])
 
     The data structure as resolved by parser's subsequent tooling. Usually obtained by expanding MSON Type references.
-
-### Data Structures (object)
-List of arbitrary data structures defined in API Blueprint.
-
-#### Properties
-+ `types` (array[[Data Structure][]]) - Array of defined data structures
 
 ## Media Types
 The `application/vnd.apiblueprint.ast` is the base media type for API Blueprint AST. An API Blueprint AST with raw Markdown descriptions has the `.raw` suffix whereas version with Markdown descriptions rendered into HTML has the `.html` suffix. The base media type serialization format is specified in the `+<serialization format>` appendix.
@@ -396,6 +390,62 @@ Two supported, feature-equal serialization formats are JSON and YAML:
           ]
         }
       ]
+    }
+  ],
+  "dataStructures": [
+    {
+      "source": {
+        "name": {
+          "literal": "<data structure name>",
+          "variable": false
+        },
+        "typeDefinition": {
+          "typeSpecification": {
+            "name": "object",
+            "nestedTypes": []
+          },
+          "attributes": []
+        },
+        "sections": [
+          {
+            "class": "memberType",
+            "content": [
+              {
+                "content": {
+                  "name": {
+                    "literal": "<property name>",
+                    "variable": false
+                  },
+                  "description": "",
+                  "valueDefinition": {
+                    "values": [
+                      {
+                        "literal": "<value>",
+                        "variable": false
+                      }
+                    ],
+                    "typeDefinition": {
+                      "typeSpecification": {
+                        "name": "string",
+                        "nestedTypes": []
+                      },
+                      "attributes": []
+                    }
+                  },
+                  "sections": [
+                    {
+                      "class": "blockDescription",
+                      "content": "<property description>"
+                    }
+                  ]
+                },
+                "class": "property"
+              }
+            ]
+          }
+        ]
+      },
+      "resolved": {}
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Description of one resource, or a cluster of resources defined by its URI templa
 + `uriTemplate` (string) - URI Template as defined in [RFC6570](http://tools.ietf.org/html/rfc6570)
 + `model` ([Payload][]) - [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection), a reusable payload representing the resource
 + `parameters` (array[[Parameter][]]) - Ordered array of URI parameters
-+ `attributes` ([Attributes][]) - Description of the Resource attributes.
++ `traits` ([Traits][]) - Description of the Resource traits.
 + `actions` (array[[Action][]]) - Ordered array of actions available on the resource each defining at least one complete HTTP transaction
 
 ### Action (object)
@@ -73,7 +73,7 @@ An HTTP transaction (a request-response transaction). Actions are specified by a
 + `description` (string) - Description of the Action (`.raw` or `.html`)
 + `method` (string) - HTTP request method defining the action
 + `parameters` (array[[Parameter][]]) - Ordered array of resource's URI parameters descriptions specific to this action
-+ `attributes` ([Attributes][]) - Description of the action input attributes – the default properties of the request message-body.
++ `traits` ([Traits][]) - Description of the action input traits – the default properties of the request message-body.
 + `examples` (array[[Transaction Example][]]) - Ordered array of HTTP transaction [examples](#example-section) for the relevant HTTP request method
 
 ### Payload (object)
@@ -90,7 +90,7 @@ An [API Blueprint payload](https://github.com/apiaryio/api-blueprint/blob/master
 
 + `reference` ([Reference][]) - Present if and only if a reference to a [Resource Model](https://github.com/apiaryio/api-blueprint/blob/master/API%20Blueprint%20Specification.md#ResourceModelSection) is present in the payload and it has been resolved correctly
 + `description` (string) - Description of the payload (`.raw` or `.html`)
-+ `attributes` ([Attributes][]) - Description of the message-body attributes
++ `traits` ([Traits][]) - Description of the message-body traits
 + `headers` (string) - Ordered array of HTTP headers that are expected to be transferred with HTTP message represented by this payload
 + `body` (string) - **Deprecated**
 
@@ -149,8 +149,8 @@ A reference object which is used whenever there is a reference to a [Resource Mo
 #### Properties
 + `id` (string) - The identifier (name) of the reference
 
-### Attributes ([Data Structure][])
-Data structure definition as written in an API Blueprint [Attributes section][Attribute section].
+### Traits ([Data Structure][])
+Data structure definition as written in an API Blueprint [Traits section][Traits section].
 
 ### Data Structure (object)
 Definition of an [MSON][] data structure.
@@ -204,7 +204,7 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                 "value": "<HTTP header field value>"
               }
             ],
-            "attributes": {
+            "traits": {
               "source": {
                 "name": null,
                 "base": {
@@ -212,8 +212,9 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                     "name": "<sub-type>"
                   }
                 },
-                "sections": null
-              }
+                "sections": []
+              },
+              "resolved": {}
             },
             "assets": {
               "body": {
@@ -239,7 +240,7 @@ Two supported, feature-equal serialization formats are JSON and YAML:
               ]
             }
           ],
-          "attributes": {
+          "traits": {
             "source": {
               "name": {
                 "literal": "<resource name>"
@@ -249,8 +250,9 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                   "name": "<sub-type>"
                 }
               },
-              "sections": null
-            }
+              "sections": []
+            },
+            "resolved": {}
           },
           "actions": [
             {
@@ -272,7 +274,7 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                   ]
                 }
               ],
-              "attributes": {
+              "traits": {
                 "source": {
                   "name": null,
                   "base": {
@@ -280,8 +282,9 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                       "name": "<sub-type>"
                     }
                   },
-                  "sections": null
-                }
+                  "sections": []
+                },
+                "resolved": {}
               },
               "examples": [
                 {
@@ -297,7 +300,7 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                           "value": "<HTTP header field value>"
                         }
                       ],
-                      "attributes": {
+                      "traits": {
                         "source": {
                           "name": null,
                           "base": {
@@ -305,7 +308,7 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                               "name": "<sub-type>"
                             }
                           },
-                          "sections": null
+                          "sections": []
                         }
                       },
                       "assets": {
@@ -328,7 +331,7 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                           "value": "<HTTP header field value>"
                         }
                       ],
-                      "attributes": {
+                      "traits": {
                         "source": {
                           "name": null,
                           "base": {
@@ -336,8 +339,9 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                               "name": "<sub-type>"
                             }
                           },
-                          "sections": null
-                        }
+                          "sections": []
+                        },
+                        "resolved": {}
                       },
                       "assets": {
                         "body": {
@@ -473,7 +477,7 @@ MIT License. See the [LICENSE](LICENSE) file.
 
 [API Blueprint asset]: https://github.com/apiaryio/api-blueprint/blob/master/Glossary%20of%20Terms.md#asset
 
-[Attribute section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-attributes-section
+[Traits section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-attributes-section
 [Resource section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-resource-section
 
 [Blueprint]: #blueprint-object
@@ -485,8 +489,7 @@ MIT License. See the [LICENSE](LICENSE) file.
 [Asset]: #asset-object
 [Parameter]: #parameter-object
 [Transaction Example]: #transaction-example-object
-[Attributes]: #attributes-data-structure
+[Traits]: #traits-data-structure
 [Data Structure]: #data-structure-object
-[Data Structures]: #data-structures-object
 
 [Source Map Definition]: Source%20Map.md

--- a/README.md
+++ b/README.md
@@ -218,10 +218,12 @@ Two supported, feature-equal serialization formats are JSON and YAML:
             },
             "assets": {
               "body": {
-                "source": "<resource model body>"
+                "source": "<resource model body>",
+                "resolved": ""
               },
               "schema": {
-                "source": "<resource model schema>"
+                "source": "<resource model schema>",
+                "resolved": ""
               }
             }
           },
@@ -313,10 +315,12 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                       },
                       "assets": {
                         "body": {
-                          "source": "<request body>"
+                          "source": "<request body>",
+                          "resolved": ""
                         },
                         "schema": {
-                          "source": "<request schema>"
+                          "source": "<request schema>",
+                          "resolved": ""
                         }
                       }
                     }
@@ -345,10 +349,12 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                       },
                       "assets": {
                         "body": {
-                          "source": "<response body>"
+                          "source": "<response body>",
+                          "resolved": ""
                         },
                         "schema": {
-                          "source": "<response schema>"
+                          "source": "<response schema>",
+                          "resolved": ""
                         }
                       }
                     }
@@ -380,10 +386,12 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                       ],
                       "assets": {
                         "body": {
-                          "source": "<resource model body>"
+                          "source": "<resource model body>",
+                          "resolved": ""
                         },
                         "schema": {
-                          "source": "<resource model schema>"
+                          "source": "<resource model schema>",
+                          "resolved": ""
                         }
                       }
                     }


### PR DESCRIPTION
* Blueprint object contains `dataStructures` which is just a plain array of all the `Data Structures` in the API Blueprint.
* Converted all Resource attributes to Resource traits. Similarly for Payload & Action. (Still need to fix the link after api-blueprint is updated)
* Corrected some serialisation in the example

@zdne I think we have lost sight of why we wanted to change the AST. The *JDOM* is a great concept and I am excited about it too. But, I think we should convert the whole AST into *JDOM* at once, not bit by bit. We should not have the AST half of the old format and half of the new format.

So, I made this pull request such that we can make a release in the old AST format. I kept in mind the possible future conflicts of key names and made room for them.