### PR TITLE
Added uriTemplate and relation attributes for action element

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ An HTTP transaction (a request-response transaction). Actions are specified by a
 + `method` (string) - HTTP request method defining the action
 + `parameters` (array[[Parameter][]]) - Ordered array of resource's URI parameters descriptions specific to this action
 + `examples` (array[[Transaction Example][]]) - Ordered array of HTTP transaction [examples](#example-section) for the relevant HTTP request method
++ `attributes` (object) - Action-specific attributes
+    + `uriTemplate` (string) - URI Template as defined in [RFC6570](http://tools.ietf.org/html/rfc6570)
+    + `relation` (string) - Link relation identifier of the action as defined in [Relation section][]
 + `content` (array[[Data Structure][]])  - Array of Action's elements
 
     In the interim period this may contain at maximum one
@@ -514,6 +517,7 @@ MIT License. See the [LICENSE](LICENSE) file.
 
 [Attribute section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-attributes-section
 [Resource section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-resource-section
+[Relation section]: https://github.com/apiaryio/api-blueprint/blob/zdne/attributes-description/API%20Blueprint%20Specification.md#def-relation-section
 
 [Blueprint]: #blueprint-object
 [Element]: #element-object

--- a/Source Map.md
+++ b/Source Map.md
@@ -74,6 +74,9 @@ Source map of the [Action][].
 + `method` ([Source Map][]) - Source map of HTTP request method defining the action
 + `parameters` (array[[Parameter Source Map][]]) - Ordered array of source maps of resource's URI parameters descriptions specific to this action
 + `examples` (array[[Transaction Example Source Map][]]) - Ordered array of source maps of HTTP transaction [examples](#example-section) for the relevant HTTP request method
++ `attributes` (object)
+    + `uriTemplate` (string) - Source map of URI Template
+    + `relation` (string) - Source map of link relation identifier of the action
 + `content` (array[[Data Structure Source Map][]]) - Ordered array of Action source map's elements
 
 ### Payload Source Map (object)


### PR DESCRIPTION
I think both the `uriTemplate` and `relation` should be in `attributes` of the action element. Please provide arguments if you disagree.