### PR TITLE
Switch from MSON-AST to Data Struct Refract

### DIFF
--- a/Parse Result.md
+++ b/Parse Result.md
@@ -5,10 +5,10 @@ This document describes API Blueprint Serialized Parse Result Media Types – th
 
 ## Version
 
-+ **Version**: 2.1
++ **Version**: 2.2
 + **Created**: 2014-06-09
-+ **Updated**: 2014-11-27
-+ **AST Serialization Media Types**: 3.0
++ **Updated**: 2015-09-07
++ **AST Serialization Media Types**: 4.0
 
 ---
 
@@ -62,21 +62,19 @@ Description of a warning from the parser.
 
 ## Media Types
 
-The base media type for API Blueprint Parsing result is `application/vnd.apiblueprint.parseresult`. A Parse Result with raw Markdown descriptions in API Blueprint AST has the `.raw` suffix whereas version with Markdown descriptions rendered into HTML has the `.html`.
-
-The base media type serialization format is specified in the `+<serialization format>` appendix.
+The media type for API Blueprint Parsing result is `application/vnd.apiblueprint.parseresult`. The media type serialization format is specified in the `+<serialization format>` appendix.
 
 ### Serialization formats
 
 Two supported, feature-equal serialization formats are JSON and YAML:
 
-+ `application/vnd.apiblueprint.parseresult.raw+json` and `application/vnd.apiblueprint.parseresult.html+json`
-+ `application/vnd.apiblueprint.parseresult.raw+yaml` and `application/vnd.apiblueprint.parseresult.html+yaml`
++ `application/vnd.apiblueprint.parseresult.json`
++ `application/vnd.apiblueprint.parseresult.yaml`
 
 Parser Result Media Types inherit from the respective [AST Serialization Type](README.md):
 
-+ [`application/vnd.apiblueprint.ast.*+json`](#json-serialization)
-+ `application/vnd.apiblueprint.ast.*+yaml`
++ [`application/vnd.apiblueprint.ast.json`](#json-serialization)
++ `application/vnd.apiblueprint.ast.yaml`
 + [`application/vnd.apiblueprint.sourcemap+json`](#json-serialization)
 + `application/vnd.apiblueprint.sourcemap+yaml`
 
@@ -86,9 +84,9 @@ Parser Result Media Types inherit from the respective [AST Serialization Type](R
 
 ```json
 {
-  "_version": "2.1",
+  "_version": "2.2",
   "ast": {
-    "_version": "3.0",
+    "_version": "4.0",
 
     ...
   },

--- a/Parse Result.md
+++ b/Parse Result.md
@@ -68,19 +68,19 @@ The media type for API Blueprint Parsing result is `application/vnd.apiblueprint
 
 Two supported, feature-equal serialization formats are JSON and YAML:
 
-+ `application/vnd.apiblueprint.parseresult.json`
-+ `application/vnd.apiblueprint.parseresult.yaml`
++ `application/vnd.apiblueprint.parseresult+json`
++ `application/vnd.apiblueprint.parseresult+yaml`
 
 Parser Result Media Types inherit from the respective [AST Serialization Type](README.md):
 
-+ [`application/vnd.apiblueprint.ast.json`](#json-serialization)
-+ `application/vnd.apiblueprint.ast.yaml`
++ [`application/vnd.apiblueprint.ast+json`](#json-serialization)
++ `application/vnd.apiblueprint.ast+yaml`
 + [`application/vnd.apiblueprint.sourcemap+json`](#json-serialization)
 + `application/vnd.apiblueprint.sourcemap+yaml`
 
 ### JSON Serialization
 
-`application/vnd.apiblueprint.parseresult.*+json; version=2.1`
+`application/vnd.apiblueprint.parseresult+json; version=2.1`
 
 ```json
 {

--- a/Parse Result.md
+++ b/Parse Result.md
@@ -80,7 +80,7 @@ Parser Result Media Types inherit from the respective [AST Serialization Type](R
 
 ### JSON Serialization
 
-`application/vnd.apiblueprint.parseresult+json; version=2.1`
+`application/vnd.apiblueprint.parseresult+json; version=2.2`
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ A reference object which is used whenever there is a reference to a [Resource Mo
 #### Properties
 + `id` (string) - The identifier (name) of the reference
 
-### Data Structure ([Named Type][])
-Definition of an [MSON][] data structure.
+### Data Structure ([Data Structure Element][])
+Definition of an [MSON][] data structure serialized as a refracted [Data Structure Element][].
 
 #### Properties
 - `element`: `dataStructure` (fixed, required)
@@ -261,14 +261,11 @@ Two supported, feature-equal serialization formats are JSON and YAML:
             ],
             "content": [
               {
-                "element": "dataStructure",
-                "name": null,
-                "base": {
-                  "typeSpecification": {
-                    "name": "<sub-type>"
-                  }
+                "element": "object",
+                "attributes": {
+                  "typeAttributes": ["<sub-type>"]
                 },
-                "sections": []
+                "content": []
               },
               {
                 "element": "asset",
@@ -337,14 +334,11 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                       ],
                       "content": [
                         {
-                          "element": "dataStructure",
-                          "name": null,
-                          "base": {
-                            "typeSpecification": {
-                              "name": "<sub-type>"
-                            }
+                          "element": "object",
+                          "attributes": {
+                            "typeAttributes": ["<sub-type>"]
                           },
-                          "sections": []
+                          "content": []
                         },
                         {
                           "element": "asset",
@@ -375,14 +369,11 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                       ],
                       "content": [
                         {
-                          "element": "dataStructure",
-                          "name": null,
-                          "base": {
-                            "typeSpecification": {
-                              "name": "<sub-type>"
-                            }
+                          "element": "object",
+                          "attributes": {
+                            "typeAttributes": ["<sub-type>"]
                           },
-                          "sections": []
+                          "content": []
                         },
                         {
                           "element": "asset",
@@ -405,14 +396,11 @@ Two supported, feature-equal serialization formats are JSON and YAML:
               ],
               "content": [
                 {
-                  "element": "dataStructure",
-                  "name": null,
-                  "base": {
-                    "typeSpecification": {
-                      "name": "<sub-type>"
-                    }
+                  "element": "object",
+                  "attributes": {
+                    "typeAttributes": ["<sub-type>"]
                   },
-                  "sections": []
+                  "content": []
                 }
               ]
             },
@@ -462,17 +450,14 @@ Two supported, feature-equal serialization formats are JSON and YAML:
           ],
           "content": [
             {
-              "element": "dataStructure",
-              "name": {
-                "literal": "<resource name>",
-                "variable": false
+              "element": "object",
+              "meta": {
+                "name": "<resource-name>"
               },
-              "base": {
-                "typeSpecification": {
-                  "name": "<sub-type>"
-                }
+              "attributes": {
+                "typeAttributes": ["<sub-type>"]
               },
-              "sections": []
+              "content": []
             }
           ]
         }
@@ -482,17 +467,14 @@ Two supported, feature-equal serialization formats are JSON and YAML:
       "element": "category",
       "content": [
         {
-          "element": "dataStructure",
-          "name": {
-            "literal": "<data structure name>",
-            "variable": false
+          "element": "object",
+          "meta": {
+            "name": "<data-structure-name>"
           },
-          "base": {
-            "typeSpecification": {
-              "name": "<sub-type>"
-            }
+          "attributes": {
+            "typeAttributes": ["<sub-type>"]
           },
-          "sections": []
+          "content": []
         }
       ]
     }
@@ -512,13 +494,8 @@ MIT License. See the [LICENSE](LICENSE) file.
 [Parsing media types]: Parse%20Result.md
 
 [MSON]: https://github.com/apiaryio/mson
-[MSON AST]: https://github.com/apiaryio/mson-ast
-[MSON Named Type]: https://github.com/apiaryio/mson/blob/master/MSON%20Specification.md#22-named-types
 
-[Named Type]: https://github.com/apiaryio/mson-ast#named-type
-[Type Name]: https://github.com/apiaryio/mson-ast#type-name
-[Type Definition]: https://github.com/apiaryio/mson-ast#type-definition
-[Type Section]: https://github.com/apiaryio/mson-ast#type-section
+[Data Structure Element]: https://github.com/refractproject/refract-spec/blob/master/namespaces/data-structure-namespace.md#data-structure-element-element
 
 [API Blueprint asset]: https://github.com/apiaryio/api-blueprint/blob/master/Glossary%20of%20Terms.md#asset
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Converting API Blueprint to AST and its serialization is the task of API Bluepri
 If you are looking for a way to describe your Web API without using JSON or YAML see [API Blueprint](https://github.com/apiaryio/api-blueprint).
 
 ## Version
-+ **Version**: 3.0
++ **Version**: 4.0
 + **Created**: 2013-08-30
-+ **Updated**: 2015-01-29
++ **Updated**: 2015-09-07
 
 ## Future Development
 As of version 3.0 the API Blueprint AST is in the *interim* transition period
@@ -204,23 +204,17 @@ A reference object which is used whenever there is a reference to a [Resource Mo
 #### Properties
 + `id` (string) - The identifier (name) of the reference
 
-### Data Structure ([Data Structure Element][])
-Definition of an [MSON][] data structure serialized as a refracted [Data Structure Element][].
-
-#### Properties
-- `element`: `dataStructure` (fixed, required)
-
 ## Media Types
-The `application/vnd.apiblueprint.ast` is the base media type for API Blueprint AST. An API Blueprint AST with raw Markdown descriptions has the `.raw` suffix whereas version with Markdown descriptions rendered into HTML has the `.html` suffix. The base media type serialization format is specified in the `+<serialization format>` appendix.
+The `application/vnd.apiblueprint.ast` is the media type for API Blueprint AST.
 
 ### Serialization formats
 Two supported, feature-equal serialization formats are JSON and YAML:
 
-+ `application/vnd.apiblueprint.ast.raw+json` and `application/vnd.apiblueprint.ast.html+json`
-+ `application/vnd.apiblueprint.ast.raw+yaml` and `application/vnd.apiblueprint.ast.html+yaml`
++ `application/vnd.apiblueprint.ast.json`
++ `application/vnd.apiblueprint.ast.yaml`
 
 ### Example: JSON Serialization
-`application/vnd.apiblueprint.ast.raw+json; version=3.0`
+`application/vnd.apiblueprint.ast.json; version=4.0`
 
 ```json
 {
@@ -264,8 +258,8 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                 "element": "dataStructure",
                 "content":{
                   "element": "object",
-                  "attributes": {
-                    "typeAttributes": ["<sub-type>"]
+                  "meta": {
+                    "ref": "<sub-type>"
                   },
                   "content": []
                 }
@@ -340,8 +334,8 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                           "element": "dataStructure",
                           "content": {
                             "element": "object",
-                            "attributes": {
-                              "typeAttributes": ["<sub-type>"]
+                            "meta": {
+                              "ref": "<sub-type>"
                             },
                             "content": []
                           }
@@ -378,8 +372,8 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                           "element": "dataStructure",
                           "content": {
                             "element": "object",
-                            "attributes": {
-                              "typeAttributes": ["<sub-type>"]
+                            "meta": {
+                              "ref": "<sub-type>"
                             },
                             "content": []
                           }
@@ -408,8 +402,8 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                   "element": "dataStructure",
                   "content": {
                     "element": "object",
-                    "attributes": {
-                      "typeAttributes": ["<sub-type>"]
+                    "meta": {
+                      "ref": "<sub-type>"
                     },
                     "content": []
                   }
@@ -466,10 +460,8 @@ Two supported, feature-equal serialization formats are JSON and YAML:
               "content": {
                 "element": "object",
                 "meta": {
-                  "id": "<resource-name>"
-                },
-                "attributes": {
-                  "typeAttributes": ["<sub-type>"]
+                  "id": "<resource-name>",
+                  "ref": "<sub-type>"
                 },
                 "content": []
               }
@@ -486,10 +478,8 @@ Two supported, feature-equal serialization formats are JSON and YAML:
           "content": {
             "element": "object",
             "meta": {
-              "id": "<data-structure-name>"
-            },
-            "attributes": {
-              "typeAttributes": ["<sub-type>"]
+              "id": "<data-structure-name>",
+              "ref": "<sub-type>"
             },
             "content": []
           }
@@ -532,7 +522,7 @@ MIT License. See the [LICENSE](LICENSE) file.
 [Parameter]: #parameter-object
 [Transaction Example]: #transaction-example-object
 [Attributes]: #attributes-data-structure
-[Data Structure]: #data-structure-object
+[Data Structure]: https://github.com/refractproject/refract-spec/blob/master/namespaces/api-description-namespace.md#data-structure-element
 [Data Structures]: #data-structures-object
 
 [Source Map Definition]: Source%20Map.md

--- a/README.md
+++ b/README.md
@@ -261,11 +261,14 @@ Two supported, feature-equal serialization formats are JSON and YAML:
             ],
             "content": [
               {
-                "element": "object",
-                "attributes": {
-                  "typeAttributes": ["<sub-type>"]
-                },
-                "content": []
+                "element": "dataStructure",
+                "content":{
+                  "element": "object",
+                  "attributes": {
+                    "typeAttributes": ["<sub-type>"]
+                  },
+                  "content": []
+                }
               },
               {
                 "element": "asset",
@@ -334,11 +337,14 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                       ],
                       "content": [
                         {
-                          "element": "object",
-                          "attributes": {
-                            "typeAttributes": ["<sub-type>"]
-                          },
-                          "content": []
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "object",
+                            "attributes": {
+                              "typeAttributes": ["<sub-type>"]
+                            },
+                            "content": []
+                          }
                         },
                         {
                           "element": "asset",
@@ -369,11 +375,14 @@ Two supported, feature-equal serialization formats are JSON and YAML:
                       ],
                       "content": [
                         {
-                          "element": "object",
-                          "attributes": {
-                            "typeAttributes": ["<sub-type>"]
-                          },
-                          "content": []
+                          "element": "dataStructure",
+                          "content": {
+                            "element": "object",
+                            "attributes": {
+                              "typeAttributes": ["<sub-type>"]
+                            },
+                            "content": []
+                          }
                         },
                         {
                           "element": "asset",
@@ -396,11 +405,14 @@ Two supported, feature-equal serialization formats are JSON and YAML:
               ],
               "content": [
                 {
-                  "element": "object",
-                  "attributes": {
-                    "typeAttributes": ["<sub-type>"]
-                  },
-                  "content": []
+                  "element": "dataStructure",
+                  "content": {
+                    "element": "object",
+                    "attributes": {
+                      "typeAttributes": ["<sub-type>"]
+                    },
+                    "content": []
+                  }
                 }
               ]
             },
@@ -450,14 +462,17 @@ Two supported, feature-equal serialization formats are JSON and YAML:
           ],
           "content": [
             {
-              "element": "object",
-              "meta": {
-                "id": "<resource-name>"
-              },
-              "attributes": {
-                "typeAttributes": ["<sub-type>"]
-              },
-              "content": []
+              "element": "dataStructure",
+              "content": {
+                "element": "object",
+                "meta": {
+                  "id": "<resource-name>"
+                },
+                "attributes": {
+                  "typeAttributes": ["<sub-type>"]
+                },
+                "content": []
+              }
             }
           ]
         }
@@ -467,14 +482,17 @@ Two supported, feature-equal serialization formats are JSON and YAML:
       "element": "category",
       "content": [
         {
-          "element": "object",
-          "meta": {
-            "id": "<data-structure-name>"
-          },
-          "attributes": {
-            "typeAttributes": ["<sub-type>"]
-          },
-          "content": []
+          "element": "dataStructure",
+          "content": {
+            "element": "object",
+            "meta": {
+              "id": "<data-structure-name>"
+            },
+            "attributes": {
+              "typeAttributes": ["<sub-type>"]
+            },
+            "content": []
+          }
         }
       ]
     }

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Two supported, feature-equal serialization formats are JSON and YAML:
             {
               "element": "object",
               "meta": {
-                "name": "<resource-name>"
+                "id": "<resource-name>"
               },
               "attributes": {
                 "typeAttributes": ["<sub-type>"]
@@ -469,7 +469,7 @@ Two supported, feature-equal serialization formats are JSON and YAML:
         {
           "element": "object",
           "meta": {
-            "name": "<data-structure-name>"
+            "id": "<data-structure-name>"
           },
           "attributes": {
             "typeAttributes": ["<sub-type>"]

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ A reference object which is used whenever there is a reference to a [Resource Mo
 + `id` (string) - The identifier (name) of the reference
 
 ## Media Types
-The `application/vnd.apiblueprint.ast` is the media type for API Blueprint AST.
+The `application/vnd.apiblueprint.ast` is the media type for API Blueprint AST. The media type serialization format is specified in the `+<serialization format>` appendix.
 
 ### Serialization formats
 Two supported, feature-equal serialization formats are JSON and YAML:
@@ -502,8 +502,6 @@ MIT License. See the [LICENSE](LICENSE) file.
 [Parsing media types]: Parse%20Result.md
 
 [MSON]: https://github.com/apiaryio/mson
-
-[Data Structure Element]: https://github.com/refractproject/refract-spec/blob/master/namespaces/data-structure-namespace.md#data-structure-element-element
 
 [API Blueprint asset]: https://github.com/apiaryio/api-blueprint/blob/master/Glossary%20of%20Terms.md#asset
 


### PR DESCRIPTION
This removes all references to the MSON-AST and replaces the example with refracted objects.