### PR TITLE
Update link to API Elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ## Deprecation Notice
 
-As of 2015-12-02 the API Blueprint AST is deprecated and should not be used for new development. The API Blueprint AST has been superseded by [API Description Refract Namespace](https://github.com/refractproject/refract-spec/blob/master/namespaces/api-description-namespace.md).
+As of 2015-12-02 the API Blueprint AST is deprecated and should not be used for new development. The API Blueprint AST has been superseded by [API Elements](https://github.com/apiaryio/api-elements).
 
 ### JSON & YAML face of the API Blueprint
 API Blueprint AST is JSON or YAML, machine-friendly, face of API Blueprint suitable for use in [tools](http://apiblueprint.org/#tooling) consuming (or producing) API Blueprint.


### PR DESCRIPTION
The existing link went to the API Description namespace which is also deprecated.

![screen shot 2017-03-31 at 11 10 36](https://cloud.githubusercontent.com/assets/44164/24544214/b964a978-1602-11e7-96f6-29e1571f8b1a.png)
